### PR TITLE
feat: add theme system, player bar refresh, and extended format support

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,7 @@ if str(SRC_DIR) not in sys.path:
     sys.path.insert(0, str(SRC_DIR))
 
 from core.state import AppState, Notify
-from db.database import initialize_database
+from db.database import get_config, initialize_database
 from player.player import Player
 from ui.app_theme import apply_app_theme
 from ui.main_window import MainWindow
@@ -53,9 +53,8 @@ def init_app_state() -> AppState:
 
 def main() -> int:
     qt_app = QApplication(sys.argv)
-    apply_app_theme(qt_app)
-
     app_state = init_app_state()
+    apply_app_theme(qt_app, get_config(app_state.db).theme_mode)
     main_window = MainWindow(app_state)
     main_window.show()
 

--- a/src/core/embed_lyrics.py
+++ b/src/core/embed_lyrics.py
@@ -185,7 +185,7 @@ def _embed_mp3(path: str, plain: Optional[str], synced: Optional[str]) -> None:
     tags.save(path)
 
 
-def _write_id3_lyrics(tags, plain: Optional[str], synced: Optional[str]) -> None:
+def _write_id3_lyrics(tags: ID3, plain: Optional[str], synced: Optional[str]) -> None:
     tags.delall("USLT")
     tags.delall(f"TXXX:{ID3_SYNCED_DESC}")
     tags.delall(f"TXXX:{ID3_PLAIN_DESC}")

--- a/src/core/embed_lyrics.py
+++ b/src/core/embed_lyrics.py
@@ -5,6 +5,7 @@ from typing import Optional
 from pathlib import Path
 
 from mutagen import File as MutagenFile
+from mutagen.asf import ASF, ASFUnicodeAttribute
 from mutagen.id3 import ID3, USLT, TXXX, ID3NoHeaderError
 from mutagen.flac import FLAC
 from mutagen.oggvorbis import OggVorbis
@@ -22,6 +23,8 @@ ID3_PLAIN_DESC = "UNSYNCEDLYRICS"
 
 MP4_PLAIN_KEY = "\xa9lyr"
 MP4_SYNCED_KEY = "----:com.lrclib:LYRICS"  # custom atom name; keep stable across app versions
+ASF_PLAIN_KEY = "WM/Lyrics"
+ASF_SYNCED_KEY = "LRCLIB_LRC"
 
 
 def _strip_timestamps(lrc: str) -> str:
@@ -81,6 +84,8 @@ def embed_lyrics_in_file(path: str, plain: Optional[str], synced: Optional[str])
         ".opus": _embed_ogg_opus,
         ".m4a": _embed_mp4,
         ".mp4": _embed_mp4,
+        ".wma": _embed_asf,
+        ".asf": _embed_asf,
     }
 
     ext = Path(path).suffix.lower()
@@ -190,5 +195,21 @@ def _embed_mp4(path: str, plain: Optional[str], synced: Optional[str]) -> None:
         audio[MP4_SYNCED_KEY] = [synced.encode("utf-8")]
     elif MP4_SYNCED_KEY in audio:
         del audio[MP4_SYNCED_KEY]
+
+    audio.save()
+
+
+def _embed_asf(path: str, plain: Optional[str], synced: Optional[str]) -> None:
+    audio = ASF(path)
+
+    if ASF_PLAIN_KEY in audio:
+        del audio[ASF_PLAIN_KEY]
+    if ASF_SYNCED_KEY in audio:
+        del audio[ASF_SYNCED_KEY]
+
+    if plain:
+        audio[ASF_PLAIN_KEY] = [ASFUnicodeAttribute(plain)]
+    if synced:
+        audio[ASF_SYNCED_KEY] = [ASFUnicodeAttribute(synced)]
 
     audio.save()

--- a/src/core/embed_lyrics.py
+++ b/src/core/embed_lyrics.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from mutagen import File as MutagenFile
 from mutagen.asf import ASF, ASFUnicodeAttribute
+from mutagen.dsf import DSF
+from mutagen.dsdiff import DSDIFF
 from mutagen.id3 import ID3, USLT, TXXX, ID3NoHeaderError
 from mutagen.flac import FLAC
 from mutagen.oggvorbis import OggVorbis
@@ -86,6 +88,8 @@ def embed_lyrics_in_file(path: str, plain: Optional[str], synced: Optional[str])
         ".mp4": _embed_mp4,
         ".wma": _embed_asf,
         ".asf": _embed_asf,
+        ".dsf": _embed_dsf,
+        ".dff": _embed_dsdiff,
     }
 
     ext = Path(path).suffix.lower()
@@ -181,6 +185,38 @@ def _embed_mp3(path: str, plain: Optional[str], synced: Optional[str]) -> None:
     tags.save(path)
 
 
+def _write_id3_lyrics(tags, plain: Optional[str], synced: Optional[str]) -> None:
+    tags.delall("USLT")
+    tags.delall(f"TXXX:{ID3_SYNCED_DESC}")
+    tags.delall(f"TXXX:{ID3_PLAIN_DESC}")
+
+    if plain:
+        tags.add(
+            USLT(
+                encoding=3,
+                lang="und",
+                desc="",
+                text=plain,
+            )
+        )
+        tags.add(
+            TXXX(
+                encoding=3,
+                desc=ID3_PLAIN_DESC,
+                text=plain,
+            )
+        )
+
+    if synced:
+        tags.add(
+            TXXX(
+                encoding=3,
+                desc=ID3_SYNCED_DESC,
+                text=synced,
+            )
+        )
+
+
 def _embed_mp4(path: str, plain: Optional[str], synced: Optional[str]) -> None:
     audio = MP4(path)
 
@@ -212,4 +248,20 @@ def _embed_asf(path: str, plain: Optional[str], synced: Optional[str]) -> None:
     if synced:
         audio[ASF_SYNCED_KEY] = [ASFUnicodeAttribute(synced)]
 
+    audio.save()
+
+
+def _embed_dsf(path: str, plain: Optional[str], synced: Optional[str]) -> None:
+    audio = DSF(path)
+    if getattr(audio, "tags", None) is None:
+        audio.add_tags()
+    _write_id3_lyrics(audio.tags, plain, synced)
+    audio.save()
+
+
+def _embed_dsdiff(path: str, plain: Optional[str], synced: Optional[str]) -> None:
+    audio = DSDIFF(path)
+    if getattr(audio, "tags", None) is None:
+        audio.add_tags()
+    _write_id3_lyrics(audio.tags, plain, synced)
     audio.save()

--- a/src/library/fs_track.py
+++ b/src/library/fs_track.py
@@ -1,17 +1,14 @@
 import os
 import glob
 from pathlib import Path
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional, List
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
 from mutagen import File as MutagenFile
-from mutagen.mp3 import MP3
-from mutagen.flac import FLAC
-from mutagen.mp4 import MP4
-from mutagen.oggvorbis import OggVorbis
-from mutagen.oggopus import OggOpus
+
+from library.scan_library import AUDIO_EXTS
 
 # ---- Structuri ----
 @dataclass
@@ -122,7 +119,7 @@ def load_tracks_from_directories(directories: List[str], db_add_tracks_callback,
         entry_batch = []
         pattern = os.path.join(directory, "**", "*.*")
         for file_path in glob.glob(pattern, recursive=True):
-            if file_path.lower().endswith(('.mp3', '.m4a', '.flac', '.ogg', '.opus', '.wav', '.wma', '.asf', '.dsf', '.dff')):
+            if Path(file_path).suffix.lower() in AUDIO_EXTS:
                 entry_batch.append(file_path)
                 if len(entry_batch) == 100:
                     tracks = load_tracks_from_entry_batch(entry_batch)
@@ -147,6 +144,6 @@ def count_files_from_directories(directories: List[str]) -> int:
         pattern = os.path.join(directory, "**", "*.*")
         files_count += sum(
             1 for f in glob.glob(pattern, recursive=True)
-            if f.lower().endswith(('.mp3', '.m4a', '.flac', '.ogg', '.opus', '.wav', '.wma', '.asf', '.dsf', '.dff'))
+            if Path(f).suffix.lower() in AUDIO_EXTS
         )
     return files_count

--- a/src/library/fs_track.py
+++ b/src/library/fs_track.py
@@ -122,7 +122,7 @@ def load_tracks_from_directories(directories: List[str], db_add_tracks_callback,
         entry_batch = []
         pattern = os.path.join(directory, "**", "*.*")
         for file_path in glob.glob(pattern, recursive=True):
-            if file_path.lower().endswith(('.mp3', '.m4a', '.flac', '.ogg', '.opus', '.wav')):
+            if file_path.lower().endswith(('.mp3', '.m4a', '.flac', '.ogg', '.opus', '.wav', '.wma', '.asf')):
                 entry_batch.append(file_path)
                 if len(entry_batch) == 100:
                     tracks = load_tracks_from_entry_batch(entry_batch)
@@ -147,6 +147,6 @@ def count_files_from_directories(directories: List[str]) -> int:
         pattern = os.path.join(directory, "**", "*.*")
         files_count += sum(
             1 for f in glob.glob(pattern, recursive=True)
-            if f.lower().endswith(('.mp3', '.m4a', '.flac', '.ogg', '.opus', '.wav'))
+            if f.lower().endswith(('.mp3', '.m4a', '.flac', '.ogg', '.opus', '.wav', '.wma', '.asf'))
         )
     return files_count

--- a/src/library/fs_track.py
+++ b/src/library/fs_track.py
@@ -122,7 +122,7 @@ def load_tracks_from_directories(directories: List[str], db_add_tracks_callback,
         entry_batch = []
         pattern = os.path.join(directory, "**", "*.*")
         for file_path in glob.glob(pattern, recursive=True):
-            if file_path.lower().endswith(('.mp3', '.m4a', '.flac', '.ogg', '.opus', '.wav', '.wma', '.asf')):
+            if file_path.lower().endswith(('.mp3', '.m4a', '.flac', '.ogg', '.opus', '.wav', '.wma', '.asf', '.dsf', '.dff')):
                 entry_batch.append(file_path)
                 if len(entry_batch) == 100:
                     tracks = load_tracks_from_entry_batch(entry_batch)
@@ -147,6 +147,6 @@ def count_files_from_directories(directories: List[str]) -> int:
         pattern = os.path.join(directory, "**", "*.*")
         files_count += sum(
             1 for f in glob.glob(pattern, recursive=True)
-            if f.lower().endswith(('.mp3', '.m4a', '.flac', '.ogg', '.opus', '.wav', '.wma', '.asf'))
+            if f.lower().endswith(('.mp3', '.m4a', '.flac', '.ogg', '.opus', '.wav', '.wma', '.asf', '.dsf', '.dff'))
         )
     return files_count

--- a/src/library/scan_library.py
+++ b/src/library/scan_library.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 from mutagen import File as MutagenFile
+from mutagen.asf import ASF
 from mutagen.id3 import ID3, USLT, TXXX, ID3NoHeaderError
 from mutagen.flac import FLAC
 from mutagen.oggvorbis import OggVorbis
@@ -24,7 +25,10 @@ from core.embed_lyrics import (
 
 logger = logging.getLogger(__name__)
 
-AUDIO_EXTS = {".mp3", ".m4a", ".flac", ".ogg", ".opus", ".wav"}
+AUDIO_EXTS = {".mp3", ".m4a", ".flac", ".ogg", ".opus", ".wav", ".wma", ".asf"}
+
+ASF_PLAIN_KEYS = ("WM/Lyrics", "LYRICS", "UNSYNCEDLYRICS")
+ASF_SYNCED_KEYS = ("LRCLIB_LRC", "SYNCEDLYRICS")
 
 def iter_audio_paths(directories: list[str]) -> list[str]:
     paths: list[str] = []
@@ -89,6 +93,7 @@ def read_embedded_lyrics(path: str) -> Tuple[Optional[str], Optional[str]]:
       - MP3: reads ID3 USLT for plain lyrics and a TXXX with desc 'LRCLIB_LRC' for synced.
       - FLAC/Vorbis/Ogg: reads 'LYRICS' and 'LRCLIB_LRC' vorbis comments.
       - MP4/M4A: reads '\xa9lyr' and '----:com.lrclib:lrc' (custom atom, bytes).
+      - WMA/ASF: reads ASF string attributes for plain and synced lyrics.
       - Fallback: tries MutagenFile() and some common keys.
     """
     p = Path(path)
@@ -165,12 +170,32 @@ def read_embedded_lyrics(path: str) -> Tuple[Optional[str], Optional[str]]:
                 else:
                     synced = str(first)
 
+        elif ext in {".wma", ".asf"}:
+            audio = ASF(path)
+
+            def _first_asf_text(keys: tuple[str, ...]) -> Optional[str]:
+                for key in keys:
+                    values = audio.tags.get(key) if getattr(audio, "tags", None) else None
+                    if not values:
+                        continue
+                    for value in values:
+                        text = getattr(value, "value", value)
+                        if text is None:
+                            continue
+                        rendered = str(text).strip()
+                        if rendered:
+                            return rendered
+                return None
+
+            plain = _first_asf_text(ASF_PLAIN_KEYS)
+            synced = _first_asf_text(ASF_SYNCED_KEYS)
+
         else:
             # Fallback generic MutagenFile with common keys
             audio = MutagenFile(path, easy=False)
             if audio is not None:
                 # Try common keys (case-sensitive and lowercase)
-                for key in (VORBIS_SYNCED_KEY, VORBIS_PLAIN_KEY, "USLT", MP4_PLAIN_KEY, MP4_SYNCED_KEY, "lyrics", "LYRICS", "LYRICS_SYNCD"):
+                for key in (VORBIS_SYNCED_KEY, VORBIS_PLAIN_KEY, "USLT", MP4_PLAIN_KEY, MP4_SYNCED_KEY, *ASF_PLAIN_KEYS, *ASF_SYNCED_KEYS, "lyrics", "LYRICS", "LYRICS_SYNCD"):
                     val = audio.tags.get(key) if getattr(audio, "tags", None) else None
                     if val:
                         # val could be list or frame; handle politely

--- a/src/library/scan_library.py
+++ b/src/library/scan_library.py
@@ -8,6 +8,8 @@ from typing import Optional, Tuple
 
 from mutagen import File as MutagenFile
 from mutagen.asf import ASF
+from mutagen.dsf import DSF
+from mutagen.dsdiff import DSDIFF
 from mutagen.id3 import ID3, USLT, TXXX, ID3NoHeaderError
 from mutagen.flac import FLAC
 from mutagen.oggvorbis import OggVorbis
@@ -25,7 +27,7 @@ from core.embed_lyrics import (
 
 logger = logging.getLogger(__name__)
 
-AUDIO_EXTS = {".mp3", ".m4a", ".flac", ".ogg", ".opus", ".wav", ".wma", ".asf"}
+AUDIO_EXTS = {".mp3", ".m4a", ".flac", ".ogg", ".opus", ".wav", ".wma", ".asf", ".dsf", ".dff"}
 
 ASF_PLAIN_KEYS = ("WM/Lyrics", "LYRICS", "UNSYNCEDLYRICS")
 ASF_SYNCED_KEYS = ("LRCLIB_LRC", "SYNCEDLYRICS")
@@ -94,6 +96,7 @@ def read_embedded_lyrics(path: str) -> Tuple[Optional[str], Optional[str]]:
       - FLAC/Vorbis/Ogg: reads 'LYRICS' and 'LRCLIB_LRC' vorbis comments.
       - MP4/M4A: reads '\xa9lyr' and '----:com.lrclib:lrc' (custom atom, bytes).
       - WMA/ASF: reads ASF string attributes for plain and synced lyrics.
+      - DSF/DSDIFF (.dff): reads ID3 lyrics frames.
       - Fallback: tries MutagenFile() and some common keys.
     """
     p = Path(path)
@@ -125,6 +128,25 @@ def read_embedded_lyrics(path: str) -> Tuple[Optional[str], Optional[str]]:
                     elif isinstance(txt, str):
                         synced = txt
                     break
+
+        elif ext in {".dsf", ".dff"}:
+            audio = DSF(path) if ext == ".dsf" else DSDIFF(path)
+            tags = getattr(audio, "tags", None)
+
+            if tags:
+                uslt_frames = tags.getall("USLT")
+                if uslt_frames:
+                    plain = uslt_frames[0].text if getattr(uslt_frames[0], "text", None) else None
+
+                txxx_frames = tags.getall("TXXX")
+                for t in txxx_frames:
+                    if getattr(t, "desc", "") == ID3_SYNCED_DESC:
+                        txt = getattr(t, "text", None)
+                        if isinstance(txt, (list, tuple)) and txt:
+                            synced = str(txt[0])
+                        elif isinstance(txt, str):
+                            synced = txt
+                        break
 
         elif ext in {".flac"}:
             audio = FLAC(path)

--- a/src/library/scan_library.py
+++ b/src/library/scan_library.py
@@ -197,7 +197,7 @@ def read_embedded_lyrics(path: str) -> Tuple[Optional[str], Optional[str]]:
 
             def _first_asf_text(keys: tuple[str, ...]) -> Optional[str]:
                 for key in keys:
-                    values = audio.tags.get(key) if getattr(audio, "tags", None) else None
+                    values = audio.get(key)
                     if not values:
                         continue
                     for value in values:

--- a/src/library/scan_library.py
+++ b/src/library/scan_library.py
@@ -92,7 +92,7 @@ def read_embedded_lyrics(path: str) -> Tuple[Optional[str], Optional[str]]:
     Returns (plain_lyrics_or_None, synced_lrc_or_None).
 
     Implementation notes:
-      - MP3: reads ID3 USLT for plain lyrics and a TXXX with desc 'LRCLIB_LRC' for synced.
+      - MP3: reads ID3 USLT for plain lyrics and a TXXX with desc 'LYRICS' for synced.
       - FLAC/Vorbis/Ogg: reads 'LYRICS' and 'LRCLIB_LRC' vorbis comments.
       - MP4/M4A: reads '\xa9lyr' and '----:com.lrclib:lrc' (custom atom, bytes).
       - WMA/ASF: reads ASF string attributes for plain and synced lyrics.

--- a/src/ui/app_theme.py
+++ b/src/ui/app_theme.py
@@ -1,39 +1,50 @@
 from __future__ import annotations
 
+from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QPalette
 from PySide6.QtWidgets import QApplication
 
 from ui.style_loader import load_stylesheet
+from ui.theme_tokens import STYLE_TOKENS, set_theme_tokens
 
 
-def apply_app_theme(app: QApplication) -> None:
+def _prefers_dark(app: QApplication) -> bool | None:
+    style_hints = app.styleHints()
+    color_scheme = getattr(style_hints, "colorScheme", None)
+    if callable(color_scheme):
+        return color_scheme() == Qt.ColorScheme.Dark
+    return None
+
+
+def apply_app_theme(app: QApplication, theme_mode: str | None = None) -> None:
     app.setStyle("Fusion")
+    set_theme_tokens(theme_mode, prefers_dark=_prefers_dark(app))
 
     palette = QPalette()
-    palette.setColor(QPalette.ColorRole.Window, QColor("#020617"))
-    palette.setColor(QPalette.ColorRole.WindowText, QColor("#e5e7eb"))
-    palette.setColor(QPalette.ColorRole.Base, QColor("#020617"))
-    palette.setColor(QPalette.ColorRole.AlternateBase, QColor("#030712"))
-    palette.setColor(QPalette.ColorRole.ToolTipBase, QColor("#020617"))
-    palette.setColor(QPalette.ColorRole.ToolTipText, QColor("#e5e7eb"))
-    palette.setColor(QPalette.ColorRole.Text, QColor("#e5e7eb"))
-    palette.setColor(QPalette.ColorRole.Button, QColor("#0b1222"))
-    palette.setColor(QPalette.ColorRole.ButtonText, QColor("#e5e7eb"))
+    palette.setColor(QPalette.ColorRole.Window, QColor(STYLE_TOKENS["color-bg-app"]))
+    palette.setColor(QPalette.ColorRole.WindowText, QColor(STYLE_TOKENS["color-text"]))
+    palette.setColor(QPalette.ColorRole.Base, QColor(STYLE_TOKENS["color-bg-app"]))
+    palette.setColor(QPalette.ColorRole.AlternateBase, QColor(STYLE_TOKENS["color-bg-panel"]))
+    palette.setColor(QPalette.ColorRole.ToolTipBase, QColor(STYLE_TOKENS["color-bg-panel"]))
+    palette.setColor(QPalette.ColorRole.ToolTipText, QColor(STYLE_TOKENS["color-text"]))
+    palette.setColor(QPalette.ColorRole.Text, QColor(STYLE_TOKENS["color-text"]))
+    palette.setColor(QPalette.ColorRole.Button, QColor(STYLE_TOKENS["color-bg-control"]))
+    palette.setColor(QPalette.ColorRole.ButtonText, QColor(STYLE_TOKENS["color-text"]))
     palette.setColor(QPalette.ColorRole.BrightText, QColor("#ffffff"))
-    palette.setColor(QPalette.ColorRole.Highlight, QColor("#38bdf8"))
-    palette.setColor(QPalette.ColorRole.HighlightedText, QColor("#020617"))
-    palette.setColor(QPalette.ColorRole.Link, QColor("#38bdf8"))
-    palette.setColor(QPalette.ColorRole.PlaceholderText, QColor("#6b7280"))
-    palette.setColor(QPalette.ColorRole.Mid, QColor("#1f2937"))
-    palette.setColor(QPalette.ColorRole.Dark, QColor("#111827"))
+    palette.setColor(QPalette.ColorRole.Highlight, QColor(STYLE_TOKENS["color-accent"]))
+    palette.setColor(QPalette.ColorRole.HighlightedText, QColor(STYLE_TOKENS["color-bg-app"]))
+    palette.setColor(QPalette.ColorRole.Link, QColor(STYLE_TOKENS["color-accent"]))
+    palette.setColor(QPalette.ColorRole.PlaceholderText, QColor(STYLE_TOKENS["color-placeholder"]))
+    palette.setColor(QPalette.ColorRole.Mid, QColor(STYLE_TOKENS["color-border"]))
+    palette.setColor(QPalette.ColorRole.Dark, QColor(STYLE_TOKENS["color-border-strong"]))
     palette.setColor(QPalette.ColorRole.Shadow, QColor("#000000"))
 
-    disabled_text = QColor("#6b7280")
+    disabled_text = QColor(STYLE_TOKENS["color-text-muted"])
     palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Text, disabled_text)
     palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.ButtonText, disabled_text)
     palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.WindowText, disabled_text)
-    palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Highlight, QColor("#1f2937"))
-    palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.HighlightedText, QColor("#9ca3af"))
+    palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.Highlight, QColor(STYLE_TOKENS["color-border"]))
+    palette.setColor(QPalette.ColorGroup.Disabled, QPalette.ColorRole.HighlightedText, QColor(STYLE_TOKENS["color-text-soft"]))
 
     app.setPalette(palette)
     app.setStyleSheet(load_stylesheet("app.qss"))

--- a/src/ui/delegates/actions_delegate.py
+++ b/src/ui/delegates/actions_delegate.py
@@ -23,7 +23,9 @@ class ActionsDelegate(QStyledItemDelegate):
             "success": "Done",
             "error": "Retry",
         }.get(state, "Download")
-        opt.state = QStyle.State_Enabled if state != "loading" else QStyle.State_None
+        opt.state = QStyle.State_None if state == "loading" else QStyle.State_Enabled
+        if option.state & QStyle.State_MouseOver and state != "loading":
+            opt.state |= QStyle.State_MouseOver
         QApplication.style().drawControl(QStyle.CE_PushButton, opt, painter)
 
     def editorEvent(self, event, model, option, index):

--- a/src/ui/dialogs/music_folders_dialog.py
+++ b/src/ui/dialogs/music_folders_dialog.py
@@ -4,6 +4,7 @@ from dataclasses import replace
 
 from PySide6.QtWidgets import (
     QCheckBox,
+    QComboBox,
     QDialog,
     QFileDialog,
     QGridLayout,
@@ -20,6 +21,7 @@ from PySide6.QtWidgets import (
 from core.lyrics_sidecar import DEFAULT_LYRICS_FILE_PATTERN
 from db.database import get_config, get_directories, set_config, set_directories
 from db.models import Config
+from ui.theme_tokens import get_available_themes
 
 
 class MusicFoldersDialog(QDialog):
@@ -43,6 +45,15 @@ class MusicFoldersDialog(QDialog):
         btn_layout.addWidget(self.remove_btn)
         folders_layout.addLayout(btn_layout)
         layout.addWidget(folders_box)
+
+        appearance_box = QGroupBox("Appearance")
+        appearance_layout = QGridLayout(appearance_box)
+        self.theme_combo = QComboBox()
+        for theme_key, theme_name in get_available_themes():
+            self.theme_combo.addItem(theme_name, theme_key)
+        appearance_layout.addWidget(QLabel("Theme"), 0, 0)
+        appearance_layout.addWidget(self.theme_combo, 0, 1)
+        layout.addWidget(appearance_box)
 
         lyrics_box = QGroupBox("Lyrics Export")
         lyrics_layout = QGridLayout(lyrics_box)
@@ -100,6 +111,8 @@ class MusicFoldersDialog(QDialog):
             self.list_widget.addItem(directory)
 
         config = get_config(self.app_state.db)
+        theme_idx = self.theme_combo.findData(config.theme_mode or "auto")
+        self.theme_combo.setCurrentIndex(max(0, theme_idx))
         self.save_sidecars_chk.setChecked(config.save_lyrics_sidecars)
         self.output_dir_edit.setText(config.lyrics_output_dir)
         self.pattern_edit.setText(config.lyrics_file_pattern or DEFAULT_LYRICS_FILE_PATTERN)
@@ -142,6 +155,7 @@ class MusicFoldersDialog(QDialog):
         config = get_config(self.app_state.db)
         new_config = replace(
             config,
+            theme_mode=str(self.theme_combo.currentData() or "auto"),
             save_lyrics_sidecars=self.save_sidecars_chk.isChecked(),
             try_embed_lyrics=self.embed_chk.isChecked(),
             lyrics_output_dir=self.output_dir_edit.text().strip(),

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -1,6 +1,6 @@
 from PySide6.QtWidgets import (
     QMainWindow, QWidget, QVBoxLayout, QLabel,
-    QTabWidget, QProgressBar, QMessageBox, QLineEdit, QHBoxLayout, QCheckBox, QSplitter, QBoxLayout, QPushButton
+    QTabWidget, QProgressBar, QMessageBox, QLineEdit, QHBoxLayout, QCheckBox, QSplitter, QBoxLayout, QPushButton, QApplication
 )
 from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QShortcut, QKeySequence
@@ -17,6 +17,7 @@ from ui.dialogs.publish_lyrics_dialog import PublishLyricsDialog
 from ui.dialogs.first_run_dialog import FirstRunDialog
 from player.player import NowPlaying
 from core.embed_lyrics import embed_lyrics_for_track
+from ui.app_theme import apply_app_theme
 from ui.widgets.album_list_widget import AlbumListWidget
 from ui.widgets.artist_list_widget import ArtistListWidget
 from ui.icon_loader import load_svg_icon
@@ -280,7 +281,7 @@ class MainWindow(QMainWindow):
         self._update_responsive_layout()
         QTimer.singleShot(0, self._maybe_show_first_run_onboarding)
 
-        self.setStyleSheet(self.styleSheet() + load_stylesheet("main_window.qss"))
+        self._apply_styles()
 
     def resizeEvent(self, event):
         super().resizeEvent(event)
@@ -300,8 +301,12 @@ class MainWindow(QMainWindow):
 
     # ------------------ modals ------------------
     def open_config_modal(self):
+        before = get_config(self.app_state.db).theme_mode
         dlg = MusicFoldersDialog(self.app_state, self)
         if dlg.exec():
+            after = get_config(self.app_state.db).theme_mode
+            if after != before:
+                self._apply_theme(after)
             self._apply_track_filters()
 
     def open_about_modal(self):
@@ -718,6 +723,27 @@ class MainWindow(QMainWindow):
 
         if hasattr(self, "player_bar"):
             self.player_bar.set_compact_mode(width < 980)
+
+    def _apply_styles(self):
+        self.setStyleSheet(load_stylesheet("main_window.qss"))
+
+    def _apply_theme(self, theme_mode: str):
+        app = QApplication.instance()
+        if app is not None:
+            apply_app_theme(app, theme_mode)
+
+        self._apply_styles()
+        if hasattr(self, "player_bar"):
+            self.player_bar._apply_styles()
+        if hasattr(self, "track_list"):
+            self.track_list._apply_styles()
+            self.track_list.empty_state._apply_styles()
+        if hasattr(self, "albums_tab"):
+            self.albums_tab._apply_styles()
+        if hasattr(self, "artists_tab"):
+            self.artists_tab._apply_styles()
+        if hasattr(self, "lyrics_view"):
+            self.lyrics_view._apply_styles()
 
     def _on_open_album(self, album_id: int):
         self.tabs.setCurrentWidget(self.tracks_tab)

--- a/src/ui/player_bar.py
+++ b/src/ui/player_bar.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import base64
-import struct
 from pathlib import Path
 
 from PySide6.QtCore import QSize, Qt
@@ -109,28 +108,11 @@ def _embedded_cover_bytes(audio_path: str | None) -> bytes | None:
         return None
 
     try:
-        if isinstance(audio, ASF) and getattr(audio, "tags", None):
-            for picture in audio.tags.get("WM/Picture", []):
-                raw = getattr(picture, "value", picture)
-                if not raw:
-                    continue
-                try:
-                    _picture_type, size = struct.unpack_from("<bi", raw)
-                    pos = 5
-
-                    while raw[pos:pos + 2] != b"\x00\x00":
-                        pos += 2
-                    pos += 2
-
-                    while raw[pos:pos + 2] != b"\x00\x00":
-                        pos += 2
-                    pos += 2
-
-                    image_data = raw[pos:pos + size]
-                    if image_data:
-                        return bytes(image_data)
-                except Exception:
-                    continue
+        if isinstance(audio, ASF):
+            for picture in audio.get("WM/Picture", []):
+                data = getattr(picture, "data", None)
+                if data:
+                    return bytes(data)
 
         if isinstance(audio, FLAC) and getattr(audio, "pictures", None):
             picture = audio.pictures[0]

--- a/src/ui/player_bar.py
+++ b/src/ui/player_bar.py
@@ -7,9 +7,11 @@ from PySide6.QtCore import QSize, Qt
 from PySide6.QtGui import QColor, QFont, QLinearGradient, QPainter, QPixmap
 from PySide6.QtWidgets import (
     QComboBox,
+    QGridLayout,
     QHBoxLayout,
     QLabel,
     QSlider,
+    QSizePolicy,
     QStyle,
     QToolButton,
     QVBoxLayout,
@@ -186,14 +188,21 @@ class PlayerBar(QWidget):
         self._duration_ms = 0
         self._is_playing = False
         self.setObjectName("PlayerBar")
+        self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
 
         root = QHBoxLayout(self)
-        set_layout_spacing(root, margins=(SPACE_3, SPACE_2, SPACE_3, SPACE_2), spacing=SPACE_2)
+        set_layout_spacing(root, margins=(SPACE_3, SPACE_2, SPACE_3, SPACE_2), spacing=0)
+
+        shell = QWidget()
+        shell.setObjectName("PlayerShell")
+        shell_layout = QGridLayout(shell)
+        set_layout_spacing(shell_layout, margins=(SPACE_3, SPACE_2, SPACE_3, SPACE_2), spacing=SPACE_3)
+        root.addWidget(shell)
 
         left_panel = QWidget()
         left_panel.setObjectName("PlayerMeta")
         left_layout = QHBoxLayout(left_panel)
-        set_layout_spacing(left_layout, margins=SPACE_2, spacing=4)
+        set_layout_spacing(left_layout, margins=0, spacing=SPACE_2)
 
         self.lbl_cover = QLabel()
         self.lbl_cover.setObjectName("NowPlayingCover")
@@ -226,7 +235,7 @@ class PlayerBar(QWidget):
         center_panel = QWidget()
         center_panel.setObjectName("PlayerCenter")
         center_layout = QVBoxLayout(center_panel)
-        set_layout_spacing(center_layout, margins=SPACE_2, spacing=SPACE_2)
+        set_layout_spacing(center_layout, margins=0, spacing=4)
 
         controls_row = QHBoxLayout()
         set_layout_spacing(controls_row, spacing=SPACE_2)
@@ -250,15 +259,15 @@ class PlayerBar(QWidget):
         self._icons = {
             "prev": load_svg_icon("skip-back.svg", 20, "#e5e7eb"),
             "next": load_svg_icon("skip-forward.svg", 20, "#e5e7eb"),
-            "play": load_svg_icon("play.svg", 22, "#e5e7eb"),
-            "pause": load_svg_icon("pause.svg", 22, "#e5e7eb"),
+            "play": load_svg_icon("play.svg", 28, "#e5e7eb"),
+            "pause": load_svg_icon("pause.svg", 28, "#e5e7eb"),
         }
         self.btn_prev.setIcon(self._icons["prev"])
         self.btn_next.setIcon(self._icons["next"])
         self.btn_play.setIcon(self._icons["play"])
         self.btn_prev.setIconSize(QSize(20, 20))
         self.btn_next.setIconSize(QSize(20, 20))
-        self.btn_play.setIconSize(QSize(22, 22))
+        self.btn_play.setIconSize(QSize(28, 28))
 
         controls_row.addWidget(self.btn_prev)
         controls_row.addWidget(self.btn_play)
@@ -289,7 +298,7 @@ class PlayerBar(QWidget):
         right_panel = QWidget()
         right_panel.setObjectName("PlayerExtras")
         right_layout = QVBoxLayout(right_panel)
-        set_layout_spacing(right_layout, margins=SPACE_2, spacing=SPACE_2)
+        set_layout_spacing(right_layout, margins=0, spacing=4)
 
         self.lbl_speed = QLabel("Speed")
         self.lbl_speed.setObjectName("MetaLabel")
@@ -305,11 +314,34 @@ class PlayerBar(QWidget):
 
         right_layout.addWidget(self.lbl_speed)
         right_layout.addWidget(self.cmb_speed)
-        right_layout.addStretch(1)
 
-        root.addWidget(left_panel, 3)
-        root.addWidget(center_panel, 4)
-        root.addWidget(right_panel, 0)
+        left_slot = QWidget()
+        left_slot_layout = QHBoxLayout(left_slot)
+        set_layout_spacing(left_slot_layout, margins=0, spacing=0)
+        left_slot_layout.addWidget(left_panel)
+
+        center_slot = QWidget()
+        center_slot_layout = QHBoxLayout(center_slot)
+        set_layout_spacing(center_slot_layout, margins=0, spacing=0)
+        center_slot_layout.addStretch(1)
+        center_slot_layout.addWidget(center_panel, 0, Qt.AlignHCenter | Qt.AlignVCenter)
+        center_slot_layout.addStretch(1)
+
+        right_slot = QWidget()
+        right_slot_layout = QHBoxLayout(right_slot)
+        set_layout_spacing(right_slot_layout, margins=0, spacing=0)
+        right_slot_layout.addStretch(1)
+        right_slot_layout.addWidget(right_panel, 0, Qt.AlignRight | Qt.AlignVCenter)
+
+        shell_layout.addWidget(left_slot, 0, 0)
+        shell_layout.addWidget(center_slot, 0, 1)
+        shell_layout.addWidget(right_slot, 0, 2)
+        shell_layout.setColumnStretch(0, 4)
+        shell_layout.setColumnStretch(1, 5)
+        shell_layout.setColumnStretch(2, 4)
+        shell_layout.setColumnMinimumWidth(2, 120)
+
+        center_panel.setMinimumWidth(420)
 
         self.slider.sliderPressed.connect(self._on_slider_pressed)
         self.slider.sliderReleased.connect(self._on_slider_released)
@@ -326,6 +358,7 @@ class PlayerBar(QWidget):
 
         self._apply_styles()
         self._sync_speed_from_player()
+        self.set_compact_mode(False)
 
     def set_prev_next_handlers(self, prev_fn, next_fn):
         self.btn_prev.clicked.connect(prev_fn)
@@ -340,15 +373,19 @@ class PlayerBar(QWidget):
         self.lbl_album.setVisible(not compact)
         self.lbl_speed.setVisible(not compact)
         self.lbl_title.setMinimumWidth(160 if compact else 220)
-        self.lbl_cover.setFixedSize(48 if compact else 56, 48 if compact else 56)
+        cover_size = 48 if compact else 56
+        bar_height = 98 if compact else 112
+        self.lbl_cover.setFixedSize(cover_size, cover_size)
+        self.setMinimumHeight(bar_height)
+        self.setMaximumHeight(bar_height)
 
         now_playing = None
         if self.player:
             now_playing = getattr(self.player, "track", None)
         if now_playing:
-            self.lbl_cover.setPixmap(_artwork_pixmap(now_playing.title or "?", now_playing.artist, getattr(now_playing, "path", None), 48 if compact else 56))
+            self.lbl_cover.setPixmap(_artwork_pixmap(now_playing.title or "?", now_playing.artist, getattr(now_playing, "path", None), cover_size))
         else:
-            self.lbl_cover.setPixmap(_artwork_pixmap("?", None, None, 48 if compact else 56))
+            self.lbl_cover.setPixmap(_artwork_pixmap("?", None, None, cover_size))
 
     def _on_speed_changed(self, _index: int):
         if not self.player:
@@ -385,6 +422,7 @@ class PlayerBar(QWidget):
             self.player.seek_ms(int(self.slider.value()), exact=True)
 
     def _on_track_changed(self, now_playing):
+        cover_size = self.lbl_cover.width() or 56
         if now_playing:
             artist = now_playing.artist or "Unknown Artist"
             title = now_playing.title or "Unknown"
@@ -392,12 +430,12 @@ class PlayerBar(QWidget):
             self.lbl_title.setText(title)
             self.lbl_artist.setText(artist)
             self.lbl_album.setText(album)
-            self.lbl_cover.setPixmap(_artwork_pixmap(title, artist, getattr(now_playing, "path", None), 56))
+            self.lbl_cover.setPixmap(_artwork_pixmap(title, artist, getattr(now_playing, "path", None), cover_size))
         else:
             self.lbl_title.setText("Nothing playing")
             self.lbl_artist.setText("Choose a track to start playback")
             self.lbl_album.setText("")
-            self.lbl_cover.setPixmap(_artwork_pixmap("?", None, None, 56))
+            self.lbl_cover.setPixmap(_artwork_pixmap("?", None, None, cover_size))
             self.slider.setValue(0)
             self.lbl_time.setText("0:00")
             self.lbl_dur.setText("0:00")

--- a/src/ui/player_bar.py
+++ b/src/ui/player_bar.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import struct
 from pathlib import Path
 
 from PySide6.QtCore import QSize, Qt
@@ -21,6 +22,7 @@ from mutagen import File as MutagenFile
 from mutagen.flac import FLAC, Picture
 from mutagen.id3 import APIC
 from mutagen.mp4 import MP4, MP4Cover
+from mutagen.asf import ASF
 from mutagen.oggopus import OggOpus
 from mutagen.oggvorbis import OggVorbis
 
@@ -107,6 +109,29 @@ def _embedded_cover_bytes(audio_path: str | None) -> bytes | None:
         return None
 
     try:
+        if isinstance(audio, ASF) and getattr(audio, "tags", None):
+            for picture in audio.tags.get("WM/Picture", []):
+                raw = getattr(picture, "value", picture)
+                if not raw:
+                    continue
+                try:
+                    _picture_type, size = struct.unpack_from("<bi", raw)
+                    pos = 5
+
+                    while raw[pos:pos + 2] != b"\x00\x00":
+                        pos += 2
+                    pos += 2
+
+                    while raw[pos:pos + 2] != b"\x00\x00":
+                        pos += 2
+                    pos += 2
+
+                    image_data = raw[pos:pos + size]
+                    if image_data:
+                        return bytes(image_data)
+                except Exception:
+                    continue
+
         if isinstance(audio, FLAC) and getattr(audio, "pictures", None):
             picture = audio.pictures[0]
             return bytes(getattr(picture, "data", b"") or b"")

--- a/src/ui/qss/app.qss
+++ b/src/ui/qss/app.qss
@@ -1,6 +1,7 @@
 QWidget {
     background-color: {{color-bg-app}};
     color: {{color-text}};
+    font-family: {{font-family-base}};
 }
 
 QMainWindow, QMenuBar, QStatusBar, QSplitter::handle {
@@ -29,7 +30,7 @@ QLineEdit:focus, QTextEdit:focus, QPlainTextEdit:focus, QComboBox:focus {
 }
 
 QLineEdit:hover, QTextEdit:hover, QPlainTextEdit:hover, QComboBox:hover {
-    border-color: #334155;
+    border-color: {{color-border-hover}};
 }
 
 QLineEdit:focus, QTextEdit:focus, QPlainTextEdit:focus, QComboBox:focus,
@@ -56,21 +57,21 @@ QPushButton:hover {
 }
 
 QPushButton[actionState="loading"] {
-    background-color: #0f172a;
-    border-color: #38bdf8;
-    color: #e0f2fe;
+    background-color: {{color-bg-pressed}};
+    border-color: {{color-accent}};
+    color: {{color-text-strong}};
 }
 
 QPushButton[actionState="success"] {
-    background-color: #052e1a;
-    border-color: #16a34a;
-    color: #dcfce7;
+    background-color: {{color-success-bg}};
+    border-color: {{color-success-border}};
+    color: {{color-success-text}};
 }
 
 QPushButton[actionState="error"] {
-    background-color: #2a0a0a;
-    border-color: #ef4444;
-    color: #fee2e2;
+    background-color: {{color-error-bg}};
+    border-color: {{color-error-border}};
+    color: {{color-error-text}};
 }
 
 QPushButton:pressed {
@@ -78,9 +79,9 @@ QPushButton:pressed {
 }
 
 QPushButton:disabled, QLineEdit:disabled, QTextEdit:disabled, QComboBox:disabled {
-    color: #6b7280;
-    border-color: #172033;
-    background: #08101f;
+    color: {{color-disabled-text}};
+    border-color: {{color-disabled-border}};
+    background: {{color-disabled-bg}};
 }
 
 QCheckBox {
@@ -100,7 +101,7 @@ QCheckBox::indicator {
 
 QCheckBox::indicator:unchecked {
     background: {{color-bg-control}};
-    border-color: #475569;
+    border-color: {{color-border}};
 }
 
 QCheckBox::indicator:checked {
@@ -124,17 +125,17 @@ QCheckBox::indicator:focus {
 }
 
 QCheckBox:disabled {
-    color: #6b7280;
+    color: {{color-disabled-text}};
 }
 
 QCheckBox::indicator:disabled {
-    background: #0f172a;
-    border-color: #1e293b;
+    background: {{color-disabled-bg}};
+    border-color: {{color-disabled-border}};
 }
 
 QCheckBox::indicator:checked:disabled {
-    background: #334155;
-    border-color: #334155;
+    background: {{color-disabled-border}};
+    border-color: {{color-disabled-border}};
 }
 
 QComboBox {
@@ -216,24 +217,24 @@ QMenu::item {
 }
 
 QMenu::item:selected {
-    background: #111827;
+    background: {{color-menu-hover}};
 }
 
 QScrollBar:vertical, QScrollBar:horizontal {
-    background: #020617;
+    background: {{color-scrollbar-track}};
     border: none;
     margin: 0px;
 }
 
 QScrollBar::handle:vertical, QScrollBar::handle:horizontal {
-    background: #1f2937;
+    background: {{color-scrollbar-handle}};
     border-radius: 6px;
     min-height: 24px;
     min-width: 24px;
 }
 
 QScrollBar::handle:vertical:hover, QScrollBar::handle:horizontal:hover {
-    background: #38bdf8;
+    background: {{color-scrollbar-hover}};
 }
 
 QScrollBar::add-line, QScrollBar::sub-line, QScrollBar::add-page, QScrollBar::sub-page {

--- a/src/ui/qss/data_table.qss
+++ b/src/ui/qss/data_table.qss
@@ -1,27 +1,31 @@
 QTableView#{{table_name}} {
-    background-color: #020617;
-    alternate-background-color: #030712;
+    background-color: {{color-table-bg}};
+    alternate-background-color: {{color-table-alt}};
     border: none;
-    color: #e5e7eb;
-    gridline-color: #020617;
-    selection-background-color: rgba(56, 189, 248, 0.2);
-    selection-color: #e5e7eb;
+    color: {{color-text}};
+    gridline-color: {{color-table-grid}};
+    selection-background-color: {{color-selection-bg}};
+    selection-color: {{color-selection-text}};
+}
+
+QTableView#{{table_name}}::item:hover {
+    background-color: {{color-table-row-hover}};
 }
 
 QHeaderView::section {
-    background-color: #020617;
-    color: #9ca3af;
+    background-color: {{color-table-header}};
+    color: {{color-table-header-text}};
     padding: 4px 24px 4px 6px;
     border: none;
-    border-bottom: 1px solid #111827;
+    border-bottom: 1px solid {{color-border-strong}};
     font-size: 11px;
     text-transform: uppercase;
     letter-spacing: 0.08em;
 }
 
 QHeaderView::section:hover {
-    background-color: #0b1222;
-    color: #d1d5db;
+    background-color: {{color-table-header-hover}};
+    color: {{color-table-header-text-hover}};
 }
 
 QTableView::item {

--- a/src/ui/qss/empty_state.qss
+++ b/src/ui/qss/empty_state.qss
@@ -7,13 +7,13 @@ QLabel#EmptyStateIcon {
 }
 
 QLabel#EmptyStateTitle {
-    color: #e5e7eb;
+    color: {{color-empty-title}};
     font-size: 18px;
     font-weight: 650;
 }
 
 QLabel#EmptyStateBody {
-    color: #94a3b8;
+    color: {{color-empty-body}};
     font-size: 12px;
     line-height: 1.4;
 }

--- a/src/ui/qss/lyrics_editor.qss
+++ b/src/ui/qss/lyrics_editor.qss
@@ -4,25 +4,25 @@ QLabel#LyricsTitle {
 }
 
 QLabel#LyricsMessage {
-    color: rgba(229, 231, 235, 0.75);
+    color: {{color-empty-body}};
 }
 
 QLabel#LyricsValidationHint {
     border-radius: {{radius-md}};
     padding: 6px {{space-3}};
-    background: {{color-bg-pressed}};
+    background: {{color-validation-bg}};
     color: {{color-text}};
-    border: 1px solid #1e293b;
+    border: 1px solid {{color-validation-border}};
 }
 
 QLabel#LyricsValidationHint[validationState="error"] {
-    background: rgba(127, 29, 29, 0.35);
-    color: #fecaca;
-    border-color: rgba(248, 113, 113, 0.35);
+    background: {{color-error-bg}};
+    color: {{color-error-text}};
+    border-color: {{color-error-border}};
 }
 
 QLabel#LyricsValidationHint[validationState="success"] {
-    background: rgba(20, 83, 45, 0.35);
-    color: #bbf7d0;
-    border-color: rgba(74, 222, 128, 0.35);
+    background: {{color-success-bg}};
+    color: {{color-success-text}};
+    border-color: {{color-success-border}};
 }

--- a/src/ui/qss/main_window.qss
+++ b/src/ui/qss/main_window.qss
@@ -45,15 +45,15 @@ QToolButton#TopBarAction[actionState="loading"] {
 }
 
 QToolButton#TopBarAction[actionState="success"] {
-    background: #052e1a;
-    border-color: #16a34a;
-    color: #86efac;
+    background: {{color-success-bg}};
+    border-color: {{color-success-border}};
+    color: {{color-success-text}};
 }
 
 QToolButton#TopBarAction[actionState="error"] {
-    background: #2a0a0a;
-    border-color: #ef4444;
-    color: #fca5a5;
+    background: {{color-error-bg}};
+    border-color: {{color-error-border}};
+    color: {{color-error-text}};
 }
 
 QWidget#ScanRow {
@@ -86,7 +86,7 @@ QProgressBar#ScanProgress::chunk {
     border-radius: 999px;
     background: qlineargradient(
         x1: 0, y1: 0, x2: 1, y2: 0,
-        stop: 0 #38bdf8, stop: 1 #22c55e
+        stop: 0 {{color-slider-fill-start}}, stop: 1 {{color-slider-fill-end}}
     );
 }
 

--- a/src/ui/qss/player_bar.qss
+++ b/src/ui/qss/player_bar.qss
@@ -3,30 +3,35 @@ QWidget#PlayerBar {
     border-top: 1px solid {{color-border-strong}};
 }
 
+QWidget#PlayerShell {
+    background: {{color-bg-panel}};
+    border: 1px solid {{color-border-strong}};
+    border-radius: {{radius-xl}};
+}
+
+QWidget#PlayerBar[compact="true"] QWidget#PlayerShell {
+    border-radius: {{radius-lg}};
+}
+
 QWidget#PlayerBar[compact="true"] QWidget#PlayerExtras {
     min-width: 84px;
-}
-
-QWidget#PlayerBar[compact="true"] QLabel#NowPlaying {
-    font-size: 13px;
-}
-
-QWidget#PlayerBar[compact="true"] QLabel#NowPlayingArtist {
-    font-size: 10px;
 }
 
 QWidget#PlayerMeta,
 QWidget#PlayerCenter,
 QWidget#PlayerExtras {
-    background: {{color-bg-panel}};
-    border: 1px solid {{color-border-strong}};
-    border-radius: {{radius-lg}};
+    background: transparent;
+    border: none;
+}
+
+QWidget#PlayerCenter {
+    min-height: 72px;
 }
 
 QToolButton {
     border: 1px solid transparent;
     background: transparent;
-    padding: {{space-2}};
+    padding: 6px;
     border-radius: {{radius-md}};
     color: {{color-text}};
 }
@@ -45,7 +50,9 @@ QToolButton#BtnPlay {
     background: {{color-bg-elevated}};
     border: 1px solid {{color-border}};
     border-radius: {{radius-pill}};
-    padding: 10px;
+    padding: 14px;
+    min-width: 54px;
+    min-height: 54px;
     color: {{color-text}};
 }
 
@@ -80,6 +87,15 @@ QLabel#NowPlayingAlbum {
     font-size: {{font-size-sm}};
 }
 
+QWidget#PlayerBar[compact="true"] QLabel#NowPlaying {
+    font-size: 13px;
+}
+
+QWidget#PlayerBar[compact="true"] QLabel#NowPlayingArtist,
+QWidget#PlayerBar[compact="true"] QLabel#NowPlayingAlbum {
+    font-size: 10px;
+}
+
 QLabel#MetaLabel,
 QLabel#TimeLabel {
     color: {{color-text}};
@@ -97,6 +113,7 @@ QSlider#PlayerSlider::groove:horizontal {
     height: 8px;
     background: {{color-bg-pressed}};
     border-radius: 4px;
+    margin: 2px 0;
 }
 
 QSlider#PlayerSlider::handle:horizontal {
@@ -130,9 +147,9 @@ QComboBox#SpeedCombo {
     background: {{color-bg-control}};
     border: 1px solid {{color-border}};
     border-radius: {{radius-md}};
-    padding: 8px 10px;
+    padding: 6px 10px;
     color: {{color-text}};
-    min-width: 84px;
+    min-width: 88px;
     font-size: {{font-size-sm}};
 }
 

--- a/src/ui/qss/player_bar.qss
+++ b/src/ui/qss/player_bar.qss
@@ -51,12 +51,12 @@ QToolButton#BtnPlay {
 
 QToolButton#BtnPlay:hover {
     border-color: {{color-accent}};
-    background: #08101f;
+    background: {{color-bg-control}};
     color: {{color-accent}};
 }
 
 QToolButton#BtnPlay:pressed {
-    background: #0f172a;
+    background: {{color-bg-pressed}};
 }
 
 QLabel {
@@ -76,7 +76,7 @@ QLabel#NowPlayingArtist {
 }
 
 QLabel#NowPlayingAlbum {
-    color: #64748b;
+    color: {{color-text-muted}};
     font-size: {{font-size-sm}};
 }
 
@@ -89,7 +89,7 @@ QLabel#TimeLabel {
 
 QLabel#NowPlayingCover {
     background: {{color-bg-pressed}};
-    border: 1px solid #1e293b;
+    border: 1px solid {{color-cover-border}};
     border-radius: 12px;
 }
 
@@ -105,20 +105,24 @@ QSlider#PlayerSlider::handle:horizontal {
     margin: -5px 0;
     border-radius: 8px;
     background: {{color-accent}};
-    border: 2px solid #e0f2fe;
+    border: 2px solid {{color-slider-handle-border}};
 }
 
 QSlider#PlayerSlider::handle:horizontal:hover {
-    background: #7dd3fc;
+    background: {{color-accent-alt}};
 }
 
 QSlider#PlayerSlider::sub-page:horizontal {
-    background: qlineargradient(x1:0, y1:0, x2:1, y2:0, stop:0 #38bdf8, stop:1 #0ea5e9);
+    background: qlineargradient(
+        x1:0, y1:0, x2:1, y2:0,
+        stop:0 {{color-slider-fill-start}},
+        stop:1 {{color-slider-fill-end}}
+    );
     border-radius: 4px;
 }
 
 QSlider#PlayerSlider::add-page:horizontal {
-    background: #0f172a;
+    background: {{color-bg-pressed}};
     border-radius: 4px;
 }
 

--- a/src/ui/qss/toast.qss
+++ b/src/ui/qss/toast.qss
@@ -17,6 +17,6 @@ QToolButton {
 }
 
 QToolButton:hover {
-    background: rgba(255, 255, 255, 0.06);
+    background: {{hover_bg}};
     border-radius: 8px;
 }

--- a/src/ui/theme_tokens.py
+++ b/src/ui/theme_tokens.py
@@ -1,27 +1,459 @@
 from __future__ import annotations
 
+from copy import deepcopy
 
-COLOR_TOKENS = {
-    "color-bg-app": "#020617",
-    "color-bg-panel": "#040b19",
-    "color-bg-control": "#0b1222",
-    "color-bg-elevated": "#111827",
-    "color-bg-pressed": "#0f172a",
-    "color-border": "#1f2937",
-    "color-border-strong": "#111827",
-    "color-accent": "#38bdf8",
-    "color-text": "#e5e7eb",
-    "color-text-strong": "#f8fafc",
-    "color-text-muted": "#94a3b8",
-    "color-text-soft": "#9ca3af",
-}
 
-RADIUS_TOKENS = {
-    "radius-sm": "8px",
-    "radius-md": "10px",
-    "radius-lg": "14px",
-    "radius-xl": "16px",
-    "radius-pill": "999px",
+def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    value = hex_color.lstrip("#")
+    if len(value) == 3:
+        value = "".join(ch * 2 for ch in value)
+    return int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16)
+
+
+def _rgba(hex_color: str, alpha: float) -> str:
+    r, g, b = _hex_to_rgb(hex_color)
+    return f"rgba({r}, {g}, {b}, {alpha:.3f})"
+
+
+def _theme(
+    *,
+    name: str,
+    bg_app: str,
+    bg_panel: str,
+    bg_control: str,
+    bg_elevated: str,
+    bg_pressed: str,
+    border: str,
+    border_strong: str,
+    accent: str,
+    text: str,
+    text_strong: str,
+    text_muted: str,
+    text_soft: str,
+    palette_mode: str,
+    accent_alt: str | None = None,
+    font_family: str = "'Segoe UI', 'Segoe UI Variable Text', system-ui, sans-serif",
+    radius_scale: str = "default",
+    extra: dict[str, str] | None = None,
+) -> dict[str, str]:
+    accent_alt = accent_alt or accent
+    theme = {
+        "theme-name": name,
+        "palette-mode": palette_mode,
+        "font-family-base": font_family,
+        "color-bg-app": bg_app,
+        "color-bg-panel": bg_panel,
+        "color-bg-control": bg_control,
+        "color-bg-elevated": bg_elevated,
+        "color-bg-pressed": bg_pressed,
+        "color-border": border,
+        "color-border-strong": border_strong,
+        "color-border-hover": accent,
+        "color-accent": accent,
+        "color-accent-alt": accent_alt,
+        "color-text": text,
+        "color-text-strong": text_strong,
+        "color-text-muted": text_muted,
+        "color-text-soft": text_soft,
+        "color-placeholder": text_muted,
+        "color-selection-bg": _rgba(accent, 0.18 if palette_mode == "dark" else 0.14),
+        "color-selection-text": text_strong,
+        "color-menu-hover": bg_elevated,
+        "color-scrollbar-track": bg_app,
+        "color-scrollbar-handle": border,
+        "color-scrollbar-hover": accent,
+        "color-disabled-text": "#6b7280" if palette_mode == "dark" else "#9ca3af",
+        "color-disabled-bg": bg_pressed,
+        "color-disabled-border": border_strong,
+        "color-success-bg": "#052e1a",
+        "color-success-border": "#16a34a",
+        "color-success-text": "#dcfce7",
+        "color-error-bg": "#2a0a0a",
+        "color-error-border": "#ef4444",
+        "color-error-text": "#fee2e2",
+        "color-warning-bg": "#2a1a05",
+        "color-warning-border": "#f59e0b",
+        "color-warning-text": "#fde68a",
+        "color-table-bg": bg_app,
+        "color-table-alt": bg_panel,
+        "color-table-grid": bg_app,
+        "color-table-header": bg_app,
+        "color-table-header-hover": bg_control,
+        "color-table-header-text": text_muted,
+        "color-table-header-text-hover": text,
+        "color-table-row-hover": _rgba(accent, 0.10 if palette_mode == "dark" else 0.08),
+        "color-cover-border": border,
+        "color-slider-fill-start": accent,
+        "color-slider-fill-end": accent_alt,
+        "color-slider-handle-border": text_strong,
+        "color-empty-title": text_strong,
+        "color-empty-body": text_muted,
+        "color-validation-bg": bg_pressed,
+        "color-validation-border": border,
+    }
+
+    if radius_scale == "round":
+        theme.update({
+            "radius-sm": "10px",
+            "radius-md": "14px",
+            "radius-lg": "18px",
+            "radius-xl": "22px",
+            "radius-pill": "999px",
+        })
+    elif radius_scale == "sharp":
+        theme.update({
+            "radius-sm": "6px",
+            "radius-md": "8px",
+            "radius-lg": "10px",
+            "radius-xl": "12px",
+            "radius-pill": "999px",
+        })
+    else:
+        theme.update({
+            "radius-sm": "8px",
+            "radius-md": "10px",
+            "radius-lg": "14px",
+            "radius-xl": "16px",
+            "radius-pill": "999px",
+        })
+
+    if extra:
+        theme.update(extra)
+    return theme
+
+
+THEMES = {
+    "LightTheme": _theme(
+        name="Light",
+        bg_app="#fafafa",
+        bg_panel="#ffffff",
+        bg_control="#f3f4f6",
+        bg_elevated="#ffffff",
+        bg_pressed="#e5e7eb",
+        border="#d1d5db",
+        border_strong="#cbd5e1",
+        accent="#3f51b5",
+        accent_alt="#5f5fc4",
+        text="#111827",
+        text_strong="#030712",
+        text_muted="#6b7280",
+        text_soft="#4b5563",
+        palette_mode="light",
+    ),
+    "DarkTheme": _theme(
+        name="Dark",
+        bg_app="#303030",
+        bg_panel="#343434",
+        bg_control="#3a3a3a",
+        bg_elevated="#424242",
+        bg_pressed="#262626",
+        border="#4b5563",
+        border_strong="#1f2937",
+        accent="#90caf9",
+        accent_alt="#0085ff",
+        text="#e5e7eb",
+        text_strong="#ffffff",
+        text_muted="#cbd5e1",
+        text_soft="#94a3b8",
+        palette_mode="dark",
+    ),
+    "AmusicTheme": _theme(
+        name="AMusic",
+        bg_app="#111111",
+        bg_panel="#1a1a1a",
+        bg_control="#1d1d1d",
+        bg_elevated="#242424",
+        bg_pressed="#2c2c2c",
+        border="#3a3a3a",
+        border_strong="#2a2a2a",
+        accent="#ff4e6b",
+        accent_alt="#D60017",
+        text="#eeeeee",
+        text_strong="#ffffff",
+        text_muted="#b3b3b3",
+        text_soft="#cccccc",
+        palette_mode="dark",
+    ),
+    "CatppuccinMacchiatoTheme": _theme(
+        name="Catppuccin Macchiato",
+        bg_app="#1e2030",
+        bg_panel="#24273a",
+        bg_control="#303347",
+        bg_elevated="#363a4f",
+        bg_pressed="#1b1d2b",
+        border="#494d64",
+        border_strong="#363a4f",
+        accent="#c6a0f6",
+        accent_alt="#8aadf4",
+        text="#cad3f5",
+        text_strong="#f4f4fa",
+        text_muted="#8aadf4",
+        text_soft="#a5adcb",
+        palette_mode="dark",
+        radius_scale="round",
+    ),
+    "DraculaTheme": _theme(
+        name="Dracula",
+        bg_app="#282a36",
+        bg_panel="#21222c",
+        bg_control="#44475a",
+        bg_elevated="#383a4a",
+        bg_pressed="#191a21",
+        border="#6272a4",
+        border_strong="#44475a",
+        accent="#bd93f9",
+        accent_alt="#50fa7b",
+        text="#f8f8f2",
+        text_strong="#ffffff",
+        text_muted="#8be9fd",
+        text_soft="#f1fa8c",
+        palette_mode="dark",
+        extra={
+            "color-table-row-hover": _rgba("#ff79c6", 0.18),
+            "color-empty-body": "#8be9fd",
+            "color-slider-fill-start": "#bd93f9",
+            "color-slider-fill-end": "#50fa7b",
+        },
+    ),
+    "ElectricPurpleTheme": _theme(
+        name="Electric Purple",
+        bg_app="#1f1230",
+        bg_panel="#2c1646",
+        bg_control="#401a66",
+        bg_elevated="#530099",
+        bg_pressed="#32124f",
+        border="#6d28d9",
+        border_strong="#4c1d95",
+        accent="#bf00ff",
+        accent_alt="#ff3f00",
+        text="#f5eaff",
+        text_strong="#ffffff",
+        text_muted="#f757ff",
+        text_soft="#ffff82",
+        palette_mode="dark",
+        extra={
+            "color-table-row-hover": _rgba("#ff763a", 0.20),
+            "color-slider-fill-end": "#fff14e",
+        },
+    ),
+    "ExtraDarkTheme": _theme(
+        name="Extra Dark",
+        bg_app="#000000",
+        bg_panel="#050505",
+        bg_control="#0d0d0d",
+        bg_elevated="#151515",
+        bg_pressed="#080808",
+        border="#202020",
+        border_strong="#101010",
+        accent="#0f60b6",
+        accent_alt="#0f60b6",
+        text="#eeeeee",
+        text_strong="#ffffff",
+        text_muted="#909090",
+        text_soft="#737373",
+        palette_mode="dark",
+        radius_scale="sharp",
+    ),
+    "GreenTheme": _theme(
+        name="Green",
+        bg_app="#202124",
+        bg_panel="#2b2d31",
+        bg_control="#32353b",
+        bg_elevated="#3a3f45",
+        bg_pressed="#25282d",
+        border="#3f4a42",
+        border_strong="#2b332e",
+        accent="#4caf50",
+        accent_alt="#2e7d32",
+        text="#eeeeee",
+        text_strong="#ffffff",
+        text_muted="#b7d7b8",
+        text_soft="#9fb89f",
+        palette_mode="dark",
+    ),
+    "GruvboxDarkTheme": _theme(
+        name="Gruvbox Dark",
+        bg_app="#282828",
+        bg_panel="#32302f",
+        bg_control="#3c3836",
+        bg_elevated="#49483e",
+        bg_pressed="#1f1f1f",
+        border="#5a524c",
+        border_strong="#3c3836",
+        accent="#8ec07c",
+        accent_alt="#458588",
+        text="#ebdbb2",
+        text_strong="#f9f5d7",
+        text_muted="#bdae93",
+        text_soft="#a89984",
+        palette_mode="dark",
+        extra={
+            "color-table-row-hover": _rgba("#cc241d", 0.16),
+        },
+    ),
+    "LigeraTheme": _theme(
+        name="Ligera",
+        bg_app="#f0f2f5",
+        bg_panel="#ffffff",
+        bg_control="#f8fafc",
+        bg_elevated="#ffffff",
+        bg_pressed="#e5e7eb",
+        border="#cccccc",
+        border_strong="#d6d9df",
+        accent="#0054df",
+        accent_alt="#224bff",
+        text="#232323",
+        text_strong="#0a0a0a",
+        text_muted="#656565",
+        text_soft="#464646",
+        palette_mode="light",
+        radius_scale="round",
+        font_family="'Segoe UI Variable Text', 'Segoe UI', system-ui, sans-serif",
+    ),
+    "MonokaiTheme": _theme(
+        name="Monokai",
+        bg_app="#272822",
+        bg_panel="#2d2e27",
+        bg_control="#3b3a32",
+        bg_elevated="#49483e",
+        bg_pressed="#1f201b",
+        border="#5a574d",
+        border_strong="#3b3a32",
+        accent="#66d9ef",
+        accent_alt="#f92672",
+        text="#f8f8f2",
+        text_strong="#ffffff",
+        text_muted="#a6a28c",
+        text_soft="#f92672",
+        palette_mode="dark",
+    ),
+    "NautilineTheme": _theme(
+        name="Nautiline",
+        bg_app="#ffffff",
+        bg_panel="#f5f5f7",
+        bg_control="#ffffff",
+        bg_elevated="#e5e5ea",
+        bg_pressed="#dfe3e8",
+        border="#d1d5db",
+        border_strong="#c7ccd1",
+        accent="#009688",
+        accent_alt="#32b8aa",
+        text="#1a1a1a",
+        text_strong="#000000",
+        text_muted="#8e8e93",
+        text_soft="#6b7280",
+        palette_mode="light",
+        radius_scale="round",
+        font_family="'Segoe UI Variable Display', 'Segoe UI', system-ui, sans-serif",
+        extra={
+            "color-bg-panel": "#f5f5f7",
+            "color-bg-control": "#ffffff",
+            "color-menu-hover": "#e5e5ea",
+            "color-table-alt": "#f5f5f7",
+        },
+    ),
+    "NordTheme": _theme(
+        name="Nord",
+        bg_app="#2e3440",
+        bg_panel="#3b4252",
+        bg_control="#434c5e",
+        bg_elevated="#4c566a",
+        bg_pressed="#252b36",
+        border="#5e81ac",
+        border_strong="#4c566a",
+        accent="#81a1c1",
+        accent_alt="#5e81ac",
+        text="#d8dee9",
+        text_strong="#eceff4",
+        text_muted="#b5c0d0",
+        text_soft="#aebbcf",
+        palette_mode="dark",
+    ),
+    "NuclearTheme": _theme(
+        name="Nuclear",
+        bg_app="#1d2021",
+        bg_panel="#282828",
+        bg_control="#32302f",
+        bg_elevated="#3a3530",
+        bg_pressed="#141617",
+        border="#665c54",
+        border_strong="#4f463f",
+        accent="#b8bb26",
+        accent_alt="#c44129",
+        text="#ebdbb2",
+        text_strong="#f9f5d7",
+        text_muted="#bdae93",
+        text_soft="#c44129",
+        palette_mode="dark",
+        extra={
+            "color-table-row-hover": _rgba("#c44129", 0.16),
+        },
+    ),
+    "NutballTheme": _theme(
+        name="Nutball",
+        bg_app="#fafafa",
+        bg_panel="#ffffff",
+        bg_control="#f3f4f6",
+        bg_elevated="#ffffff",
+        bg_pressed="#e5e7eb",
+        border="#e0e0e0",
+        border_strong="#d6d6d6",
+        accent="#80ea00",
+        accent_alt="#53b700",
+        text="#111111",
+        text_strong="#000000",
+        text_muted="#6b7280",
+        text_soft="#4b5563",
+        palette_mode="light",
+        radius_scale="round",
+    ),
+    "SpotifyTheme": _theme(
+        name="Spotify-ish",
+        bg_app="#121212",
+        bg_panel="#171717",
+        bg_control="#181818",
+        bg_elevated="#282828",
+        bg_pressed="#1d1d1d",
+        border="#28282b",
+        border_strong="#000000",
+        accent="#1db954",
+        accent_alt="#62ec83",
+        text="#ffffff",
+        text_strong="#ffffff",
+        text_muted="#b3b3b3",
+        text_soft="#c2c1c2",
+        palette_mode="dark",
+        font_family="system-ui, 'Helvetica Neue', Helvetica, Arial, sans-serif",
+        radius_scale="round",
+        extra={
+            "radius-md": "18px",
+            "radius-lg": "20px",
+            "color-table-row-hover": _rgba("#1db954", 0.12),
+        },
+    ),
+    "SquiddiesGlassTheme": _theme(
+        name="Squiddies Glass",
+        bg_app="#181818",
+        bg_panel="#1d1d1d",
+        bg_control="#282828",
+        bg_elevated="#33213b",
+        bg_pressed="#23162a",
+        border="#5e3a66",
+        border_strong="#402448",
+        accent="#c231ab",
+        accent_alt="#380eff",
+        text="#fbe3f4",
+        text_strong="#ffffff",
+        text_muted="#f5b9e3",
+        text_soft="#c2c1c2",
+        palette_mode="dark",
+        radius_scale="round",
+        extra={
+            "color-bg-panel": "rgba(29, 29, 29, 0.88)",
+            "color-table-row-hover": _rgba("#c231ab", 0.18),
+            "color-menu-hover": _rgba("#e14ac2", 0.15),
+        },
+    ),
 }
 
 FONT_TOKENS = {
@@ -39,8 +471,34 @@ SPACE_TOKENS = {
 }
 
 
-STYLE_TOKENS = {}
-STYLE_TOKENS.update(COLOR_TOKENS)
-STYLE_TOKENS.update(RADIUS_TOKENS)
-STYLE_TOKENS.update(FONT_TOKENS)
-STYLE_TOKENS.update(SPACE_TOKENS)
+def get_available_themes() -> list[tuple[str, str]]:
+    return [("auto", "Auto")] + [(key, theme["theme-name"]) for key, theme in THEMES.items()]
+
+
+def resolve_theme_key(theme_mode: str | None, *, prefers_dark: bool | None = None) -> str:
+    if theme_mode == "auto":
+        if prefers_dark is False:
+            return "LightTheme"
+        return "DarkTheme"
+    if theme_mode in THEMES:
+        return str(theme_mode)
+    return "DarkTheme"
+
+
+def get_theme_tokens(theme_mode: str | None, *, prefers_dark: bool | None = None) -> dict[str, str]:
+    tokens = deepcopy(THEMES[resolve_theme_key(theme_mode, prefers_dark=prefers_dark)])
+    tokens.update(FONT_TOKENS)
+    tokens.update(SPACE_TOKENS)
+    return tokens
+
+
+STYLE_TOKENS: dict[str, str] = {}
+
+
+def set_theme_tokens(theme_mode: str | None, *, prefers_dark: bool | None = None) -> dict[str, str]:
+    STYLE_TOKENS.clear()
+    STYLE_TOKENS.update(get_theme_tokens(theme_mode, prefers_dark=prefers_dark))
+    return STYLE_TOKENS
+
+
+set_theme_tokens("DarkTheme")

--- a/src/ui/theme_tokens.py
+++ b/src/ui/theme_tokens.py
@@ -15,6 +15,10 @@ def _rgba(hex_color: str, alpha: float) -> str:
     return f"rgba({r}, {g}, {b}, {alpha:.3f})"
 
 
+def rgba(hex_color: str, alpha: float) -> str:
+    return _rgba(hex_color, alpha)
+
+
 def _theme(
     *,
     name: str,

--- a/src/ui/widgets/empty_state_widget.py
+++ b/src/ui/widgets/empty_state_widget.py
@@ -44,7 +44,7 @@ class EmptyStateWidget(QWidget):
         layout.addWidget(self.body)
         layout.addWidget(self.action, 0, Qt.AlignmentFlag.AlignCenter)
 
-        self.setStyleSheet(load_stylesheet("empty_state.qss"))
+        self._apply_styles()
 
     def configure(
         self,
@@ -63,3 +63,6 @@ class EmptyStateWidget(QWidget):
             self.action.show()
         else:
             self.action.hide()
+
+    def _apply_styles(self):
+        self.setStyleSheet(load_stylesheet("empty_state.qss"))

--- a/src/ui/widgets/lyrics_editor_widget.py
+++ b/src/ui/widgets/lyrics_editor_widget.py
@@ -233,7 +233,7 @@ class LyricsEditorWidget(QWidget):
             self.btn_publish_plain: "Publish Plain",
         }
 
-        self.setStyleSheet(load_stylesheet("lyrics_editor.qss"))
+        self._apply_styles()
         self.show_none("Choose a track to review or edit its lyrics.")
 
     # --- public API ---
@@ -258,6 +258,11 @@ class LyricsEditorWidget(QWidget):
         self._refresh_row_styles()
 
         self.table.scrollToItem(self.table.item(idx, 1), self.table.ScrollHint.PositionAtCenter)
+
+    def _apply_styles(self):
+        self.setStyleSheet(load_stylesheet("lyrics_editor.qss"))
+        if hasattr(self, "empty_state") and self.empty_state:
+            self.empty_state._apply_styles()
 
     def show_none(self, message: str):
         self._reset_state()

--- a/src/ui/widgets/toast.py
+++ b/src/ui/widgets/toast.py
@@ -15,7 +15,7 @@ from PySide6.QtWidgets import (
 
 from ui.spacing import SPACE_2, SPACE_3, set_layout_spacing
 from ui.style_loader import load_stylesheet
-from ui.theme_tokens import STYLE_TOKENS
+from ui.theme_tokens import STYLE_TOKENS, rgba
 
 
 @dataclass(frozen=True)
@@ -24,25 +24,13 @@ class ToastData:
     notify_type: str = "info"  # "info" | "success" | "warning" | "error"
     timeout_ms: int = 3000
 
-def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
-    value = hex_color.lstrip("#")
-    if len(value) == 3:
-        value = "".join(ch * 2 for ch in value)
-    return int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16)
-
-
-def _rgba(hex_color: str, alpha: float) -> str:
-    r, g, b = _hex_to_rgb(hex_color)
-    return f"rgba({r}, {g}, {b}, {alpha:.3f})"
-
-
 def _colors(kind: str) -> tuple[str, str, str, str]:
     """
     Returns (bg, border, text, hover_bg).
     """
     kind = (kind or "info").lower()
     palette_mode = STYLE_TOKENS.get("palette-mode", "dark")
-    hover_bg = _rgba(STYLE_TOKENS.get("color-text-strong", "#ffffff"), 0.08 if palette_mode == "dark" else 0.06)
+    hover_bg = rgba(STYLE_TOKENS.get("color-text-strong", "#ffffff"), 0.08 if palette_mode == "dark" else 0.06)
 
     if kind == "success":
         return (

--- a/src/ui/widgets/toast.py
+++ b/src/ui/widgets/toast.py
@@ -15,6 +15,7 @@ from PySide6.QtWidgets import (
 
 from ui.spacing import SPACE_2, SPACE_3, set_layout_spacing
 from ui.style_loader import load_stylesheet
+from ui.theme_tokens import STYLE_TOKENS
 
 
 @dataclass(frozen=True)
@@ -23,19 +24,53 @@ class ToastData:
     notify_type: str = "info"  # "info" | "success" | "warning" | "error"
     timeout_ms: int = 3000
 
-_TOAST_COLORS = {
-    "success": ("#052e1a", "#16a34a", "#e5e7eb"),
-    "warning": ("#2a1a05", "#f59e0b", "#e5e7eb"),
-    "error": ("#2a0a0a", "#ef4444", "#e5e7eb"),
-    "info": ("#0b1222", "#38bdf8", "#e5e7eb"),
-}
+def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    value = hex_color.lstrip("#")
+    if len(value) == 3:
+        value = "".join(ch * 2 for ch in value)
+    return int(value[0:2], 16), int(value[2:4], 16), int(value[4:6], 16)
 
-def _colors(kind: str) -> tuple[str, str, str]:
+
+def _rgba(hex_color: str, alpha: float) -> str:
+    r, g, b = _hex_to_rgb(hex_color)
+    return f"rgba({r}, {g}, {b}, {alpha:.3f})"
+
+
+def _colors(kind: str) -> tuple[str, str, str, str]:
     """
-    Returns (bg, border, text).
+    Returns (bg, border, text, hover_bg).
     """
     kind = (kind or "info").lower()
-    return _TOAST_COLORS.get(kind, _TOAST_COLORS["info"])
+    palette_mode = STYLE_TOKENS.get("palette-mode", "dark")
+    hover_bg = _rgba(STYLE_TOKENS.get("color-text-strong", "#ffffff"), 0.08 if palette_mode == "dark" else 0.06)
+
+    if kind == "success":
+        return (
+            STYLE_TOKENS.get("color-success-bg", "#052e1a"),
+            STYLE_TOKENS.get("color-success-border", "#16a34a"),
+            STYLE_TOKENS.get("color-success-text", "#e5e7eb"),
+            hover_bg,
+        )
+    if kind == "warning":
+        return (
+            STYLE_TOKENS.get("color-warning-bg", "#2a1a05"),
+            STYLE_TOKENS.get("color-warning-border", "#f59e0b"),
+            STYLE_TOKENS.get("color-warning-text", "#e5e7eb"),
+            hover_bg,
+        )
+    if kind == "error":
+        return (
+            STYLE_TOKENS.get("color-error-bg", "#2a0a0a"),
+            STYLE_TOKENS.get("color-error-border", "#ef4444"),
+            STYLE_TOKENS.get("color-error-text", "#e5e7eb"),
+            hover_bg,
+        )
+    return (
+        STYLE_TOKENS.get("color-bg-control", "#0b1222"),
+        STYLE_TOKENS.get("color-accent", "#38bdf8"),
+        STYLE_TOKENS.get("color-text", "#e5e7eb"),
+        hover_bg,
+    )
 
 class ToastWidget(QFrame):
     def __init__(self, data: ToastData, parent: QWidget, manager: "ToastManager"):
@@ -43,10 +78,10 @@ class ToastWidget(QFrame):
         self.data = data
         self._manager = manager
 
-        bg, border, text = _colors(data.notify_type)
+        bg, border, text, hover_bg = _colors(data.notify_type)
 
         self.setObjectName("Toast")
-        self.setStyleSheet(load_stylesheet("toast.qss", bg=bg, border=border, text=text))
+        self.setStyleSheet(load_stylesheet("toast.qss", bg=bg, border=border, text=text, hover_bg=hover_bg))
 
         self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
 

--- a/src/ui/widgets/track_list_widget.py
+++ b/src/ui/widgets/track_list_widget.py
@@ -91,6 +91,8 @@ class TrackListWidget(QWidget):
         self.table.verticalHeader().setVisible(False)
         self.table.setShowGrid(False)
         self.table.setAlternatingRowColors(True)
+        self.table.setMouseTracking(True)
+        self.table.viewport().setMouseTracking(True)
         self.table.setSortingEnabled(True)
         self.table.sortByColumn(0, Qt.SortOrder.AscendingOrder)
 


### PR DESCRIPTION
## Summary

This PR refreshes the app UI and expands format support.

## What changed

- add Navidrome-inspired theme presets and wire them through the desktop UI
- retheme core surfaces including tables, player bar, empty states, validation states, and toasts
- redesign the player bar layout to be more compact and visually centered
- improve track table hover feedback and action button hover behavior
- add scanning and lyrics support for WMA/ASF
- add scanning and lyrics support for DSF/DFF
- add embedded WMA/ASF cover-art parsing in the player bar

## Notes

- playback for some formats still depends on the active backend available on the host system
- python syntax checks passed for modified files