### PR TITLE
feat: improve syncing workflow and incremental library scanning

### DIFF
--- a/src/core/models.py
+++ b/src/core/models.py
@@ -1,6 +1,8 @@
 # core/models.py
 from __future__ import annotations
+
 from dataclasses import dataclass
+
 
 @dataclass(frozen=True)
 class TrackRow:
@@ -10,6 +12,7 @@ class TrackRow:
     duration_s: int | None
     lyrics_state: str  # "synced" | "plain" | "instrumental" | "none"
 
+
 @dataclass(frozen=True)
 class TrackFilters:
     synced: bool = True
@@ -17,10 +20,11 @@ class TrackFilters:
     instrumental: bool = False
     no_lyrics: bool = True
 
+
 @dataclass(frozen=True)
 class FsTrack:
-    file_path: str      # FULL path to audio file (ca în Rust)
-    file_name: str      # basename (song.mp3)
+    file_path: str
+    file_name: str
     title: str
     album: str
     artist: str
@@ -29,8 +33,9 @@ class FsTrack:
     txt_lyrics: str | None
     lrc_lyrics: str | None
     track_number: int | None
+    modified_time: float | None = None
+    file_size: int | None = None
 
-    # ca să nu-ți schimbi database.py (care folosește metode)
     def file_path_(self) -> str: return self.file_path
     def file_name_(self) -> str: return self.file_name
     def title_(self) -> str: return self.title
@@ -41,3 +46,5 @@ class FsTrack:
     def txt_lyrics_(self) -> str | None: return self.txt_lyrics
     def lrc_lyrics_(self) -> str | None: return self.lrc_lyrics
     def track_number_(self) -> int | None: return self.track_number
+    def modified_time_(self) -> float | None: return self.modified_time
+    def file_size_(self) -> int | None: return self.file_size

--- a/src/db/database.py
+++ b/src/db/database.py
@@ -8,7 +8,7 @@ into migrations + queries.
 from __future__ import annotations
 
 # Public DB version (single source of truth for the app)
-CURRENT_DB_VERSION = 9
+CURRENT_DB_VERSION = 10
 
 from db.migrations import initialize_database, upgrade_database_if_needed
 from db.queries import *  # noqa: F403

--- a/src/db/database.py
+++ b/src/db/database.py
@@ -8,7 +8,7 @@ into migrations + queries.
 from __future__ import annotations
 
 # Public DB version (single source of truth for the app)
-CURRENT_DB_VERSION = 14
+CURRENT_DB_VERSION = 15
 
 from db.migrations import initialize_database, upgrade_database_if_needed
 from db.queries import *  # noqa: F403

--- a/src/db/database.py
+++ b/src/db/database.py
@@ -8,7 +8,7 @@ into migrations + queries.
 from __future__ import annotations
 
 # Public DB version (single source of truth for the app)
-CURRENT_DB_VERSION = 13
+CURRENT_DB_VERSION = 14
 
 from db.migrations import initialize_database, upgrade_database_if_needed
 from db.queries import *  # noqa: F403

--- a/src/db/database.py
+++ b/src/db/database.py
@@ -8,7 +8,7 @@ into migrations + queries.
 from __future__ import annotations
 
 # Public DB version (single source of truth for the app)
-CURRENT_DB_VERSION = 12
+CURRENT_DB_VERSION = 13
 
 from db.migrations import initialize_database, upgrade_database_if_needed
 from db.queries import *  # noqa: F403

--- a/src/db/database.py
+++ b/src/db/database.py
@@ -8,7 +8,7 @@ into migrations + queries.
 from __future__ import annotations
 
 # Public DB version (single source of truth for the app)
-CURRENT_DB_VERSION = 10
+CURRENT_DB_VERSION = 12
 
 from db.migrations import initialize_database, upgrade_database_if_needed
 from db.queries import *  # noqa: F403

--- a/src/db/migrations.py
+++ b/src/db/migrations.py
@@ -181,3 +181,13 @@ def upgrade_database_if_needed(db: sqlite3.Connection, existing_version: int) ->
             ALTER TABLE config_data ADD COLUMN playback_speed REAL DEFAULT 1.0;
         """)
         db.commit()
+
+    # v15
+    if existing_version <= 14:
+        print("Migrate database version 15...")
+        db.execute("PRAGMA user_version=15")
+        db.executescript("""
+            DROP TABLE IF EXISTS scan_directory_state;
+            DROP TABLE IF EXISTS scan_cache_meta;
+        """)
+        db.commit()

--- a/src/db/migrations.py
+++ b/src/db/migrations.py
@@ -163,3 +163,12 @@ def upgrade_database_if_needed(db: sqlite3.Connection, existing_version: int) ->
             );
         """)
         db.commit()
+
+    # v13
+    if existing_version <= 12:
+        print("Migrate database version 13...")
+        db.execute("PRAGMA user_version=13")
+        db.executescript("""
+            ALTER TABLE config_data ADD COLUMN reaction_delay_ms INTEGER DEFAULT 0;
+        """)
+        db.commit()

--- a/src/db/migrations.py
+++ b/src/db/migrations.py
@@ -125,3 +125,13 @@ def upgrade_database_if_needed(db: sqlite3.Connection, existing_version: int) ->
             UPDATE config_data SET save_lyrics_sidecars = 1;
         """)
         db.commit()
+
+    # v10
+    if existing_version <= 9:
+        print("Migrate database version 10...")
+        db.execute("PRAGMA user_version=10")
+        db.executescript("""
+            ALTER TABLE config_data ADD COLUMN scan_excluded_paths TEXT DEFAULT '';
+            ALTER TABLE config_data ADD COLUMN scan_excluded_patterns TEXT DEFAULT '';
+        """)
+        db.commit()

--- a/src/db/migrations.py
+++ b/src/db/migrations.py
@@ -172,3 +172,12 @@ def upgrade_database_if_needed(db: sqlite3.Connection, existing_version: int) ->
             ALTER TABLE config_data ADD COLUMN reaction_delay_ms INTEGER DEFAULT 0;
         """)
         db.commit()
+
+    # v14
+    if existing_version <= 13:
+        print("Migrate database version 14...")
+        db.execute("PRAGMA user_version=14")
+        db.executescript("""
+            ALTER TABLE config_data ADD COLUMN playback_speed REAL DEFAULT 1.0;
+        """)
+        db.commit()

--- a/src/db/migrations.py
+++ b/src/db/migrations.py
@@ -135,3 +135,31 @@ def upgrade_database_if_needed(db: sqlite3.Connection, existing_version: int) ->
             ALTER TABLE config_data ADD COLUMN scan_excluded_patterns TEXT DEFAULT '';
         """)
         db.commit()
+
+    # v11
+    if existing_version <= 10:
+        print("Migrate database version 11...")
+        db.execute("PRAGMA user_version=11")
+        db.executescript("""
+            ALTER TABLE tracks ADD COLUMN modified_time REAL;
+            ALTER TABLE tracks ADD COLUMN file_size INTEGER;
+            CREATE INDEX idx_tracks_file_path ON tracks(file_path);
+        """)
+        db.commit()
+
+    # v12
+    if existing_version <= 11:
+        print("Migrate database version 12...")
+        db.execute("PRAGMA user_version=12")
+        db.executescript("""
+            CREATE TABLE IF NOT EXISTS scan_directory_state (
+                path TEXT PRIMARY KEY,
+                modified_time REAL
+            );
+
+            CREATE TABLE IF NOT EXISTS scan_cache_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT
+            );
+        """)
+        db.commit()

--- a/src/db/migrations.py
+++ b/src/db/migrations.py
@@ -129,65 +129,54 @@ def upgrade_database_if_needed(db: sqlite3.Connection, existing_version: int) ->
     # v10
     if existing_version <= 9:
         print("Migrate database version 10...")
-        db.execute("PRAGMA user_version=10")
         db.executescript("""
             ALTER TABLE config_data ADD COLUMN scan_excluded_paths TEXT DEFAULT '';
             ALTER TABLE config_data ADD COLUMN scan_excluded_patterns TEXT DEFAULT '';
         """)
         db.commit()
+        db.execute("PRAGMA user_version=10")
 
     # v11
     if existing_version <= 10:
         print("Migrate database version 11...")
-        db.execute("PRAGMA user_version=11")
         db.executescript("""
             ALTER TABLE tracks ADD COLUMN modified_time REAL;
             ALTER TABLE tracks ADD COLUMN file_size INTEGER;
             CREATE INDEX idx_tracks_file_path ON tracks(file_path);
         """)
         db.commit()
+        db.execute("PRAGMA user_version=11")
 
     # v12
     if existing_version <= 11:
         print("Migrate database version 12...")
+        # Reserved migration slot kept for compatibility with pre-merge development databases.
         db.execute("PRAGMA user_version=12")
-        db.executescript("""
-            CREATE TABLE IF NOT EXISTS scan_directory_state (
-                path TEXT PRIMARY KEY,
-                modified_time REAL
-            );
-
-            CREATE TABLE IF NOT EXISTS scan_cache_meta (
-                key TEXT PRIMARY KEY,
-                value TEXT
-            );
-        """)
-        db.commit()
 
     # v13
     if existing_version <= 12:
         print("Migrate database version 13...")
-        db.execute("PRAGMA user_version=13")
         db.executescript("""
             ALTER TABLE config_data ADD COLUMN reaction_delay_ms INTEGER DEFAULT 0;
         """)
         db.commit()
+        db.execute("PRAGMA user_version=13")
 
     # v14
     if existing_version <= 13:
         print("Migrate database version 14...")
-        db.execute("PRAGMA user_version=14")
         db.executescript("""
             ALTER TABLE config_data ADD COLUMN playback_speed REAL DEFAULT 1.0;
         """)
         db.commit()
+        db.execute("PRAGMA user_version=14")
 
     # v15
     if existing_version <= 14:
         print("Migrate database version 15...")
-        db.execute("PRAGMA user_version=15")
         db.executescript("""
             DROP TABLE IF EXISTS scan_directory_state;
             DROP TABLE IF EXISTS scan_cache_meta;
         """)
         db.commit()
+        db.execute("PRAGMA user_version=15")

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -106,6 +106,7 @@ class Config:
     lyrics_file_pattern: str
     scan_excluded_paths: str
     scan_excluded_patterns: str
+    reaction_delay_ms: int
 
 
 # Keep FsTrack here too if you already have it in this file.

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -104,6 +104,8 @@ class Config:
     lrclib_instance: str
     lyrics_output_dir: str
     lyrics_file_pattern: str
+    scan_excluded_paths: str
+    scan_excluded_patterns: str
 
 
 # Keep FsTrack here too if you already have it in this file.

--- a/src/db/models.py
+++ b/src/db/models.py
@@ -107,6 +107,7 @@ class Config:
     scan_excluded_paths: str
     scan_excluded_patterns: str
     reaction_delay_ms: int
+    playback_speed: float
 
 
 # Keep FsTrack here too if you already have it in this file.

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -49,7 +49,9 @@ def get_config(db: sqlite3.Connection) -> Config:
                theme_mode,
                lrclib_instance,
                lyrics_output_dir,
-               lyrics_file_pattern
+               lyrics_file_pattern,
+               scan_excluded_paths,
+               scan_excluded_patterns
         FROM config_data
         LIMIT 1
     """).fetchone()
@@ -64,6 +66,8 @@ def get_config(db: sqlite3.Connection) -> Config:
         lrclib_instance=row["lrclib_instance"],
         lyrics_output_dir=row["lyrics_output_dir"] or "",
         lyrics_file_pattern=row["lyrics_file_pattern"] or "{artist} - {title}",
+        scan_excluded_paths=row["scan_excluded_paths"] or "",
+        scan_excluded_patterns=row["scan_excluded_patterns"] or "",
     )
 
 
@@ -78,7 +82,9 @@ def set_config(db: sqlite3.Connection, config: Config) -> None:
             theme_mode = ?,
             lrclib_instance = ?,
             lyrics_output_dir = ?,
-            lyrics_file_pattern = ?
+            lyrics_file_pattern = ?,
+            scan_excluded_paths = ?,
+            scan_excluded_patterns = ?
         WHERE 1
     """, (
         config.skip_tracks_with_synced_lyrics,
@@ -90,6 +96,8 @@ def set_config(db: sqlite3.Connection, config: Config) -> None:
         config.lrclib_instance,
         config.lyrics_output_dir,
         config.lyrics_file_pattern,
+        config.scan_excluded_paths,
+        config.scan_excluded_patterns,
     ))
     db.commit()
 

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -358,8 +358,8 @@ def add_track(db: sqlite3.Connection, track: FsTrack, *, commit: bool = True) ->
         track.txt_lyrics,
         track.lrc_lyrics,
         is_instrumental,
-        getattr(track, "modified_time", None),
-        getattr(track, "file_size", None),
+        track.modified_time,
+        track.file_size,
     ))
     if commit:
         db.commit()
@@ -369,16 +369,13 @@ def add_tracks(db: sqlite3.Connection, tracks: List[FsTrack], *, commit: bool = 
     if not tracks:
         return
     if commit:
-        db.execute("BEGIN")
-    try:
-        for t in tracks:
-            add_track(db, t, commit=False)
-        if commit:
-            db.commit()
-    except Exception:
-        if commit:
-            db.rollback()
-        raise
+        with db:
+            for t in tracks:
+                add_track(db, t, commit=False)
+        return
+
+    for t in tracks:
+        add_track(db, t, commit=False)
 
 
 def get_tracks(db: sqlite3.Connection) -> List[Track]:

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -292,8 +292,6 @@ def get_track_by_id(db: sqlite3.Connection, track_id: int) -> Track:
             album_id,
             duration,
             track_number,
-            modified_time,
-            file_size,
             albums.image_path,
             txt_lyrics,
             lrc_lyrics,

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -679,8 +679,8 @@ def delete_tracks_by_paths(db: sqlite3.Connection, paths: list[str], *, commit: 
 
 
 def prune_library(db: sqlite3.Connection) -> None:
-    db.execute("DELETE FROM albums WHERE id NOT IN (SELECT DISTINCT album_id FROM tracks)")
-    db.execute("DELETE FROM artists WHERE id NOT IN (SELECT DISTINCT artist_id FROM tracks)")
+    db.execute("DELETE FROM albums WHERE NOT EXISTS (SELECT 1 FROM tracks WHERE tracks.album_id = albums.id)")
+    db.execute("DELETE FROM artists WHERE NOT EXISTS (SELECT 1 FROM tracks WHERE tracks.artist_id = artists.id)")
     db.commit()
 
 

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -51,7 +51,8 @@ def get_config(db: sqlite3.Connection) -> Config:
                lyrics_output_dir,
                lyrics_file_pattern,
                scan_excluded_paths,
-               scan_excluded_patterns
+               scan_excluded_patterns,
+               reaction_delay_ms
         FROM config_data
         LIMIT 1
     """).fetchone()
@@ -68,6 +69,7 @@ def get_config(db: sqlite3.Connection) -> Config:
         lyrics_file_pattern=row["lyrics_file_pattern"] or "{artist} - {title}",
         scan_excluded_paths=row["scan_excluded_paths"] or "",
         scan_excluded_patterns=row["scan_excluded_patterns"] or "",
+        reaction_delay_ms=int(row["reaction_delay_ms"] or 0),
     )
 
 
@@ -84,7 +86,8 @@ def set_config(db: sqlite3.Connection, config: Config) -> None:
             lyrics_output_dir = ?,
             lyrics_file_pattern = ?,
             scan_excluded_paths = ?,
-            scan_excluded_patterns = ?
+            scan_excluded_patterns = ?,
+            reaction_delay_ms = ?
         WHERE 1
     """, (
         config.skip_tracks_with_synced_lyrics,
@@ -98,6 +101,7 @@ def set_config(db: sqlite3.Connection, config: Config) -> None:
         config.lyrics_file_pattern,
         config.scan_excluded_paths,
         config.scan_excluded_patterns,
+        config.reaction_delay_ms,
     ))
     db.commit()
 

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -120,12 +120,13 @@ def find_artist(db: sqlite3.Connection, name: str) -> int:
     raise ValueError("Artist not found")
 
 
-def add_artist(db: sqlite3.Connection, name: str) -> int:
+def add_artist(db: sqlite3.Connection, name: str, *, commit: bool = True) -> int:
     cursor = db.execute(
         "INSERT INTO artists (name, name_lower) VALUES (?, ?)",
         (name, prepare_input(name)),
     )
-    db.commit()
+    if commit:
+        db.commit()
     return int(cursor.lastrowid)
 
 
@@ -198,7 +199,7 @@ def find_album(db: sqlite3.Connection, name: str, album_artist_name: str) -> int
     raise ValueError("Album not found")
 
 
-def add_album(db: sqlite3.Connection, name: str, album_artist_name: str) -> int:
+def add_album(db: sqlite3.Connection, name: str, album_artist_name: str, *, commit: bool = True) -> int:
     cursor = db.execute(
         """
         INSERT INTO albums (name, name_lower, album_artist_name, album_artist_name_lower)
@@ -206,7 +207,8 @@ def add_album(db: sqlite3.Connection, name: str, album_artist_name: str) -> int:
         """,
         (name, prepare_input(name), album_artist_name, prepare_input(album_artist_name)),
     )
-    db.commit()
+    if commit:
+        db.commit()
     return int(cursor.lastrowid)
 
 
@@ -322,18 +324,18 @@ def get_track_by_id(db: sqlite3.Connection, track_id: int) -> Track:
     )
 
 
-def add_track(db: sqlite3.Connection, track: FsTrack) -> None:
+def add_track(db: sqlite3.Connection, track: FsTrack, *, commit: bool = True) -> None:
     # Artist
     try:
         artist_id = find_artist(db, track.artist)
     except ValueError:
-        artist_id = add_artist(db, track.artist)
+        artist_id = add_artist(db, track.artist, commit=False)
 
     # Album
     try:
         album_id = find_album(db, track.album, track.album_artist)
     except ValueError:
-        album_id = add_album(db, track.album, track.album_artist)
+        album_id = add_album(db, track.album, track.album_artist, commit=False)
 
     # Detect instrumental
     is_instrumental = bool(track.lrc_lyrics and re.search(r"\[au:\s*instrumental\]", track.lrc_lyrics))
@@ -359,12 +361,24 @@ def add_track(db: sqlite3.Connection, track: FsTrack) -> None:
         getattr(track, "modified_time", None),
         getattr(track, "file_size", None),
     ))
-    db.commit()
+    if commit:
+        db.commit()
 
 
-def add_tracks(db: sqlite3.Connection, tracks: List[FsTrack]) -> None:
-    for t in tracks:
-        add_track(db, t)
+def add_tracks(db: sqlite3.Connection, tracks: List[FsTrack], *, commit: bool = True) -> None:
+    if not tracks:
+        return
+    if commit:
+        db.execute("BEGIN")
+    try:
+        for t in tracks:
+            add_track(db, t, commit=False)
+        if commit:
+            db.commit()
+    except Exception:
+        if commit:
+            db.rollback()
+        raise
 
 
 def get_tracks(db: sqlite3.Connection) -> List[Track]:
@@ -656,11 +670,12 @@ def set_scan_cache_meta(db: sqlite3.Connection, key: str, value: str) -> None:
     db.commit()
 
 
-def delete_tracks_by_paths(db: sqlite3.Connection, paths: list[str]) -> None:
+def delete_tracks_by_paths(db: sqlite3.Connection, paths: list[str], *, commit: bool = True) -> None:
     if not paths:
         return
     db.executemany("DELETE FROM tracks WHERE file_path = ?", [(path,) for path in paths])
-    db.commit()
+    if commit:
+        db.commit()
 
 
 def prune_library(db: sqlite3.Connection) -> None:

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -368,14 +368,16 @@ def add_track(db: sqlite3.Connection, track: FsTrack, *, commit: bool = True) ->
 def add_tracks(db: sqlite3.Connection, tracks: List[FsTrack], *, commit: bool = True) -> None:
     if not tracks:
         return
+
+    def _do_add() -> None:
+        for t in tracks:
+            add_track(db, t, commit=False)
+
     if commit:
         with db:
-            for t in tracks:
-                add_track(db, t, commit=False)
-        return
-
-    for t in tracks:
-        add_track(db, t, commit=False)
+            _do_add()
+    else:
+        _do_add()
 
 
 def get_tracks(db: sqlite3.Connection) -> List[Track]:
@@ -633,38 +635,6 @@ def get_library_file_index(db: sqlite3.Connection) -> dict[str, tuple[float | No
         )
         for row in rows
     }
-
-
-def get_scan_directory_index(db: sqlite3.Connection) -> dict[str, float]:
-    rows = db.execute("SELECT path, modified_time FROM scan_directory_state").fetchall()
-    return {row["path"]: float(row["modified_time"]) for row in rows if row["modified_time"] is not None}
-
-
-def replace_scan_directory_index(db: sqlite3.Connection, entries: dict[str, float]) -> None:
-    db.execute("DELETE FROM scan_directory_state")
-    if entries:
-        db.executemany(
-            "INSERT INTO scan_directory_state (path, modified_time) VALUES (?, ?)",
-            [(path, modified_time) for path, modified_time in entries.items()],
-        )
-    db.commit()
-
-
-def get_scan_cache_meta(db: sqlite3.Connection, key: str) -> str:
-    row = db.execute("SELECT value FROM scan_cache_meta WHERE key = ? LIMIT 1", (key,)).fetchone()
-    return str(row["value"]) if row and row["value"] is not None else ""
-
-
-def set_scan_cache_meta(db: sqlite3.Connection, key: str, value: str) -> None:
-    db.execute(
-        """
-        INSERT INTO scan_cache_meta (key, value)
-        VALUES (?, ?)
-        ON CONFLICT(key) DO UPDATE SET value = excluded.value
-        """,
-        (key, value),
-    )
-    db.commit()
 
 
 def delete_tracks_by_paths(db: sqlite3.Connection, paths: list[str], *, commit: bool = True) -> None:

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -282,6 +282,8 @@ def get_track_by_id(db: sqlite3.Connection, track_id: int) -> Track:
             album_id,
             duration,
             track_number,
+            modified_time,
+            file_size,
             albums.image_path,
             txt_lyrics,
             lrc_lyrics,
@@ -332,8 +334,8 @@ def add_track(db: sqlite3.Connection, track: FsTrack) -> None:
         INSERT INTO tracks (
             file_path, file_name, title, title_lower,
             album_id, artist_id, duration, track_number,
-            txt_lyrics, lrc_lyrics, instrumental
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            txt_lyrics, lrc_lyrics, instrumental, modified_time, file_size
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     """, (
         track.file_path,
         track.file_name,
@@ -346,6 +348,8 @@ def add_track(db: sqlite3.Connection, track: FsTrack) -> None:
         track.txt_lyrics,
         track.lrc_lyrics,
         is_instrumental,
+        getattr(track, "modified_time", None),
+        getattr(track, "file_size", None),
     ))
     db.commit()
 
@@ -361,7 +365,7 @@ def get_tracks(db: sqlite3.Connection) -> List[Track]:
             tracks.id, file_path, file_name, title,
             artists.name AS artist_name, tracks.artist_id,
             albums.name AS album_name, albums.album_artist_name,
-            album_id, duration, track_number,
+            album_id, duration, track_number, modified_time, file_size,
             albums.image_path, txt_lyrics, lrc_lyrics, instrumental
         FROM tracks
         JOIN albums ON tracks.album_id = albums.id
@@ -598,6 +602,62 @@ def clean_library(db: sqlite3.Connection) -> None:
     db.execute("DELETE FROM tracks")
     db.execute("DELETE FROM albums")
     db.execute("DELETE FROM artists")
+    db.commit()
+
+
+def get_library_file_index(db: sqlite3.Connection) -> dict[str, tuple[float | None, int | None]]:
+    rows = db.execute("SELECT file_path, modified_time, file_size FROM tracks").fetchall()
+    return {
+        row["file_path"]: (
+            float(row["modified_time"]) if row["modified_time"] is not None else None,
+            int(row["file_size"]) if row["file_size"] is not None else None,
+        )
+        for row in rows
+    }
+
+
+def get_scan_directory_index(db: sqlite3.Connection) -> dict[str, float]:
+    rows = db.execute("SELECT path, modified_time FROM scan_directory_state").fetchall()
+    return {row["path"]: float(row["modified_time"]) for row in rows if row["modified_time"] is not None}
+
+
+def replace_scan_directory_index(db: sqlite3.Connection, entries: dict[str, float]) -> None:
+    db.execute("DELETE FROM scan_directory_state")
+    if entries:
+        db.executemany(
+            "INSERT INTO scan_directory_state (path, modified_time) VALUES (?, ?)",
+            [(path, modified_time) for path, modified_time in entries.items()],
+        )
+    db.commit()
+
+
+def get_scan_cache_meta(db: sqlite3.Connection, key: str) -> str:
+    row = db.execute("SELECT value FROM scan_cache_meta WHERE key = ? LIMIT 1", (key,)).fetchone()
+    return str(row["value"]) if row and row["value"] is not None else ""
+
+
+def set_scan_cache_meta(db: sqlite3.Connection, key: str, value: str) -> None:
+    db.execute(
+        """
+        INSERT INTO scan_cache_meta (key, value)
+        VALUES (?, ?)
+        ON CONFLICT(key) DO UPDATE SET value = excluded.value
+        """,
+        (key, value),
+    )
+    db.commit()
+
+
+def delete_tracks_by_paths(db: sqlite3.Connection, paths: list[str]) -> None:
+    if not paths:
+        return
+    db.executemany("DELETE FROM tracks WHERE file_path = ?", [(path,) for path in paths])
+    db.commit()
+
+
+def prune_library(db: sqlite3.Connection) -> None:
+    db.execute("DELETE FROM albums WHERE id NOT IN (SELECT DISTINCT album_id FROM tracks)")
+    db.execute("DELETE FROM artists WHERE id NOT IN (SELECT DISTINCT artist_id FROM tracks)")
     db.commit()
 
 

--- a/src/db/queries.py
+++ b/src/db/queries.py
@@ -52,7 +52,8 @@ def get_config(db: sqlite3.Connection) -> Config:
                lyrics_file_pattern,
                scan_excluded_paths,
                scan_excluded_patterns,
-               reaction_delay_ms
+               reaction_delay_ms,
+               playback_speed
         FROM config_data
         LIMIT 1
     """).fetchone()
@@ -70,6 +71,7 @@ def get_config(db: sqlite3.Connection) -> Config:
         scan_excluded_paths=row["scan_excluded_paths"] or "",
         scan_excluded_patterns=row["scan_excluded_patterns"] or "",
         reaction_delay_ms=int(row["reaction_delay_ms"] or 0),
+        playback_speed=float(row["playback_speed"] or 1.0),
     )
 
 
@@ -87,7 +89,8 @@ def set_config(db: sqlite3.Connection, config: Config) -> None:
             lyrics_file_pattern = ?,
             scan_excluded_paths = ?,
             scan_excluded_patterns = ?,
-            reaction_delay_ms = ?
+            reaction_delay_ms = ?,
+            playback_speed = ?
         WHERE 1
     """, (
         config.skip_tracks_with_synced_lyrics,
@@ -102,6 +105,7 @@ def set_config(db: sqlite3.Connection, config: Config) -> None:
         config.scan_excluded_paths,
         config.scan_excluded_patterns,
         config.reaction_delay_ms,
+        config.playback_speed,
     ))
     db.commit()
 

--- a/src/library/scan_library.py
+++ b/src/library/scan_library.py
@@ -270,59 +270,63 @@ def _read_sidecar(path: str) -> tuple[Optional[str], Optional[str]]:
 
 
 def new_fs_track_from_path(path: str) -> FsTrack | None:
-    audio = MutagenFile(path, easy=True)
-    if audio is None:
-        return None
-
-    # title/album/artist extraction
-    def _first(easy, key: str) -> str | None:
-        v = easy.get(key)
-        if not v:
-            return None
-        if isinstance(v, list):
-            return (str(v[0]).strip() if v else None) or None
-        s = str(v).strip()
-        return s or None
-
-    title = _first(audio, "title")
-    album = _first(audio, "album")
-    artist = _first(audio, "artist")
-
-    title = title or os.path.splitext(os.path.basename(path))[0]
-    album = album or "Unknown Album"
-    artist = artist or "Unknown Artist"
-
-    album_artist = (
-        _first(audio, "albumartist")
-        or _first(audio, "album artist")
-        or artist
-    )
-
-    track_number = _parse_track_number(_first(audio, "tracknumber"))
-
-    duration = 0.0
     try:
-        if getattr(audio, "info", None) and getattr(audio.info, "length", None):
-            duration = float(audio.info.length)
-    except Exception:
+        audio = MutagenFile(path, easy=True)
+        if audio is None:
+            return None
+
+        # title/album/artist extraction
+        def _first(easy, key: str) -> str | None:
+            v = easy.get(key)
+            if not v:
+                return None
+            if isinstance(v, list):
+                return (str(v[0]).strip() if v else None) or None
+            s = str(v).strip()
+            return s or None
+
+        title = _first(audio, "title")
+        album = _first(audio, "album")
+        artist = _first(audio, "artist")
+
+        title = title or os.path.splitext(os.path.basename(path))[0]
+        album = album or "Unknown Album"
+        artist = artist or "Unknown Artist"
+
+        album_artist = (
+            _first(audio, "albumartist")
+            or _first(audio, "album artist")
+            or artist
+        )
+
+        track_number = _parse_track_number(_first(audio, "tracknumber"))
+
         duration = 0.0
+        try:
+            if getattr(audio, "info", None) and getattr(audio.info, "length", None):
+                duration = float(audio.info.length)
+        except Exception:
+            duration = 0.0
 
-    # SIDE-CAR (preferred) then EMBEDDED
-    txt_sidecar, lrc_sidecar = _read_sidecar(path)
-    txt_embedded, lrc_embedded = read_embedded_lyrics(path)
+        # SIDE-CAR (preferred) then EMBEDDED
+        txt_sidecar, lrc_sidecar = _read_sidecar(path)
+        txt_embedded, lrc_embedded = read_embedded_lyrics(path)
 
-    txt_lyrics = txt_sidecar or txt_embedded
-    lrc_lyrics = lrc_sidecar or lrc_embedded
+        txt_lyrics = txt_sidecar or txt_embedded
+        lrc_lyrics = lrc_sidecar or lrc_embedded
 
-    return FsTrack(
-        file_path=path,
-        file_name=os.path.basename(path),
-        title=title,
-        album=album,
-        artist=artist,
-        album_artist=album_artist,
-        duration=duration,
-        txt_lyrics=txt_lyrics,
-        lrc_lyrics=lrc_lyrics,
-        track_number=track_number,
-    )
+        return FsTrack(
+            file_path=path,
+            file_name=os.path.basename(path),
+            title=title,
+            album=album,
+            artist=artist,
+            album_artist=album_artist,
+            duration=duration,
+            txt_lyrics=txt_lyrics,
+            lrc_lyrics=lrc_lyrics,
+            track_number=track_number,
+        )
+    except (MutagenError, Exception) as exc:
+        logger.warning("Skipping unreadable audio file during scan: %s (%s)", path, exc)
+        return None

--- a/src/library/scan_library.py
+++ b/src/library/scan_library.py
@@ -44,11 +44,10 @@ def _path_variants(path: str) -> tuple[str, str]:
     return normalized, posix
 
 
-def _normalize_excluded_paths(excluded_paths: str | None) -> list[str]:
-    normalized: list[str] = []
+def _normalize_excluded_paths(excluded_paths: str | None) -> list[tuple[str, str]]:
+    normalized: list[tuple[str, str]] = []
     for entry in _split_lines(excluded_paths):
-        native, _ = _path_variants(entry)
-        normalized.append(native)
+        normalized.append(_path_variants(entry))
     return normalized
 
 
@@ -62,14 +61,15 @@ def _compile_excluded_patterns(excluded_patterns: str | None) -> list[re.Pattern
     return compiled
 
 
-def _is_path_excluded(path: str, excluded_roots: list[str], excluded_patterns: list[re.Pattern[str]]) -> bool:
+def _is_path_excluded(path: str, excluded_roots: list[tuple[str, str]], excluded_patterns: list[re.Pattern[str]]) -> bool:
     resolved, resolved_posix = _path_variants(path)
 
-    for root in excluded_roots:
-        root_clean = root.rstrip("/\\")
-        if resolved == root_clean or resolved.startswith(root_clean + os.sep):
+    for root_native, root_posix in excluded_roots:
+        root_native_clean = root_native.rstrip("/\\")
+        root_posix_clean = root_posix.rstrip("/")
+        if resolved == root_native_clean or resolved.startswith(root_native_clean + os.sep):
             return True
-        if resolved_posix == root_clean or resolved_posix.startswith(root_clean + "/"):
+        if resolved_posix == root_posix_clean or resolved_posix.startswith(root_posix_clean + "/"):
             return True
 
     for pattern in excluded_patterns:

--- a/src/library/scan_library.py
+++ b/src/library/scan_library.py
@@ -85,6 +85,7 @@ def iter_audio_paths(
     excluded_roots = _normalize_excluded_paths(excluded_paths)
     compiled_patterns = _compile_excluded_patterns(excluded_patterns)
     paths: list[str] = []
+    seen: set[str] = set()
     for root in directories:
         if not root or not os.path.isdir(root):
             continue
@@ -92,9 +93,99 @@ def iter_audio_paths(
             for fn in filenames:
                 file_path = os.path.join(dirpath, fn)
                 ext = os.path.splitext(fn)[1].lower()
+                normalized = str(Path(file_path).resolve())
+                if normalized in seen:
+                    continue
                 if ext in AUDIO_EXTS and not _is_path_excluded(file_path, excluded_roots, compiled_patterns):
+                    seen.add(normalized)
                     paths.append(file_path)
     return paths
+
+
+def iter_audio_paths_with_directory_cache(
+    directories: list[str],
+    *,
+    existing_paths: list[str],
+    cached_directory_mtimes: dict[str, float] | None = None,
+    excluded_paths: str | None = None,
+    excluded_patterns: str | None = None,
+) -> tuple[list[str], dict[str, float]]:
+    excluded_roots = _normalize_excluded_paths(excluded_paths)
+    compiled_patterns = _compile_excluded_patterns(excluded_patterns)
+    cached_directory_mtimes = cached_directory_mtimes or {}
+    seen_paths: set[str] = set()
+    collected_paths: list[str] = []
+    directory_mtimes: dict[str, float] = {}
+
+    known_descendants: list[tuple[str, str, str]] = []
+    for original in existing_paths:
+        try:
+            resolved = str(Path(original).resolve())
+            resolved_posix = Path(original).resolve().as_posix().casefold()
+        except Exception:
+            continue
+        known_descendants.append((original, resolved.casefold(), resolved_posix))
+
+    def _collect_known_subtree(dir_path: str) -> None:
+        resolved_dir = str(Path(dir_path).resolve())
+        resolved_cf = resolved_dir.casefold().rstrip("/\\")
+        resolved_posix = Path(dir_path).resolve().as_posix().casefold().rstrip("/")
+        for original, file_cf, file_posix in known_descendants:
+            in_win_tree = file_cf == resolved_cf or file_cf.startswith(resolved_cf + os.sep.casefold())
+            in_posix_tree = file_posix == resolved_posix or file_posix.startswith(resolved_posix + "/")
+            if not in_win_tree and not in_posix_tree:
+                continue
+            if original in seen_paths:
+                continue
+            if _is_path_excluded(original, excluded_roots, compiled_patterns):
+                continue
+            seen_paths.add(original)
+            collected_paths.append(original)
+
+    def _walk_dir(dir_path: str) -> None:
+        try:
+            resolved_dir = str(Path(dir_path).resolve())
+            dir_mtime = float(os.path.getmtime(resolved_dir))
+        except OSError:
+            return
+
+        directory_mtimes[resolved_dir] = dir_mtime
+        if cached_directory_mtimes.get(resolved_dir) == dir_mtime:
+            _collect_known_subtree(resolved_dir)
+            return
+
+        try:
+            with os.scandir(resolved_dir) as entries:
+                for entry in entries:
+                    entry_path = entry.path
+                    if entry.is_dir(follow_symlinks=False):
+                        if _is_path_excluded(entry_path, excluded_roots, compiled_patterns):
+                            continue
+                        _walk_dir(entry_path)
+                        continue
+
+                    if not entry.is_file(follow_symlinks=False):
+                        continue
+
+                    ext = os.path.splitext(entry.name)[1].lower()
+                    if ext not in AUDIO_EXTS:
+                        continue
+                    normalized = str(Path(entry_path).resolve())
+                    if normalized in seen_paths:
+                        continue
+                    if _is_path_excluded(entry_path, excluded_roots, compiled_patterns):
+                        continue
+                    seen_paths.add(normalized)
+                    collected_paths.append(entry_path)
+        except OSError:
+            return
+
+    for root in directories:
+        if not root or not os.path.isdir(root):
+            continue
+        _walk_dir(root)
+
+    return collected_paths, directory_mtimes
 
 
 def preview_audio_path_exclusions(
@@ -107,6 +198,7 @@ def preview_audio_path_exclusions(
     compiled_patterns = _compile_excluded_patterns(excluded_patterns)
     included: list[str] = []
     excluded: list[str] = []
+    seen: set[str] = set()
 
     for root in directories:
         if not root or not os.path.isdir(root):
@@ -115,14 +207,35 @@ def preview_audio_path_exclusions(
             for fn in filenames:
                 file_path = os.path.join(dirpath, fn)
                 ext = os.path.splitext(fn)[1].lower()
+                normalized = str(Path(file_path).resolve())
+                if normalized in seen:
+                    continue
                 if ext not in AUDIO_EXTS:
                     continue
+                seen.add(normalized)
                 if _is_path_excluded(file_path, excluded_roots, compiled_patterns):
                     excluded.append(file_path)
                 else:
                     included.append(file_path)
 
     return included, excluded
+
+
+def get_audio_file_signature(path: str) -> tuple[float | None, int | None]:
+    newest_mtime: float | None = None
+    total_size = 0
+    base, _ = os.path.splitext(path)
+
+    for candidate in (path, base + ".txt", base + ".lrc"):
+        try:
+            stat = os.stat(candidate)
+        except OSError:
+            continue
+        candidate_mtime = float(stat.st_mtime)
+        newest_mtime = candidate_mtime if newest_mtime is None else max(newest_mtime, candidate_mtime)
+        total_size += int(stat.st_size)
+
+    return newest_mtime, total_size if newest_mtime is not None else None
 
 def _first(easy, key: str) -> str | None:
     v = easy.get(key)
@@ -395,6 +508,8 @@ def new_fs_track_from_path(path: str) -> FsTrack | None:
         txt_lyrics = txt_sidecar or txt_embedded
         lrc_lyrics = lrc_sidecar or lrc_embedded
 
+        modified_time, file_size = get_audio_file_signature(path)
+
         return FsTrack(
             file_path=path,
             file_name=os.path.basename(path),
@@ -406,6 +521,8 @@ def new_fs_track_from_path(path: str) -> FsTrack | None:
             txt_lyrics=txt_lyrics,
             lrc_lyrics=lrc_lyrics,
             track_number=track_number,
+            modified_time=modified_time,
+            file_size=file_size,
         )
     except (MutagenError, Exception) as exc:
         logger.warning("Skipping unreadable audio file during scan: %s (%s)", path, exc)

--- a/src/library/scan_library.py
+++ b/src/library/scan_library.py
@@ -47,7 +47,8 @@ def _path_variants(path: str) -> tuple[str, str]:
 def _normalize_excluded_paths(excluded_paths: str | None) -> list[tuple[str, str]]:
     normalized: list[tuple[str, str]] = []
     for entry in _split_lines(excluded_paths):
-        normalized.append(_path_variants(entry))
+        native, posix = _path_variants(entry)
+        normalized.append((native.rstrip("/\\"), posix.rstrip("/")))
     return normalized
 
 
@@ -61,19 +62,21 @@ def _compile_excluded_patterns(excluded_patterns: str | None) -> list[re.Pattern
     return compiled
 
 
-def _is_path_excluded(path: str, excluded_roots: list[tuple[str, str]], excluded_patterns: list[re.Pattern[str]]) -> bool:
-    resolved, resolved_posix = _path_variants(path)
-
+def _is_path_excluded_variants(
+    path: str,
+    normalized_path: str,
+    posix_path: str,
+    excluded_roots: list[tuple[str, str]],
+    excluded_patterns: list[re.Pattern[str]],
+) -> bool:
     for root_native, root_posix in excluded_roots:
-        root_native_clean = root_native.rstrip("/\\")
-        root_posix_clean = root_posix.rstrip("/")
-        if resolved == root_native_clean or resolved.startswith(root_native_clean + os.sep):
+        if normalized_path == root_native or normalized_path.startswith(root_native + os.sep):
             return True
-        if resolved_posix == root_posix_clean or resolved_posix.startswith(root_posix_clean + "/"):
+        if posix_path == root_posix or posix_path.startswith(root_posix + "/"):
             return True
 
     for pattern in excluded_patterns:
-        if pattern.search(path) or pattern.search(resolved_posix):
+        if pattern.search(path) or pattern.search(posix_path):
             return True
 
     return False
@@ -94,12 +97,14 @@ def iter_audio_paths(
             continue
         for dirpath, _, filenames in os.walk(root):
             for fn in filenames:
-                file_path = os.path.join(dirpath, fn)
                 ext = os.path.splitext(fn)[1].lower()
-                normalized, _ = _path_variants(file_path)
+                if ext not in AUDIO_EXTS:
+                    continue
+                file_path = os.path.join(dirpath, fn)
+                normalized, posix_path = _path_variants(file_path)
                 if normalized in seen:
                     continue
-                if ext in AUDIO_EXTS and not _is_path_excluded(file_path, excluded_roots, compiled_patterns):
+                if not _is_path_excluded_variants(file_path, normalized, posix_path, excluded_roots, compiled_patterns):
                     seen.add(normalized)
                     paths.append(file_path)
     return paths
@@ -122,15 +127,15 @@ def preview_audio_path_exclusions(
             continue
         for dirpath, _, filenames in os.walk(root):
             for fn in filenames:
-                file_path = os.path.join(dirpath, fn)
                 ext = os.path.splitext(fn)[1].lower()
-                normalized, _ = _path_variants(file_path)
-                if normalized in seen:
-                    continue
                 if ext not in AUDIO_EXTS:
                     continue
+                file_path = os.path.join(dirpath, fn)
+                normalized, posix_path = _path_variants(file_path)
+                if normalized in seen:
+                    continue
                 seen.add(normalized)
-                if _is_path_excluded(file_path, excluded_roots, compiled_patterns):
+                if _is_path_excluded_variants(file_path, normalized, posix_path, excluded_roots, compiled_patterns):
                     excluded.append(file_path)
                 else:
                     included.append(file_path)

--- a/src/library/scan_library.py
+++ b/src/library/scan_library.py
@@ -38,14 +38,17 @@ def _split_lines(block: str | None) -> list[str]:
     return [line.strip() for line in (block or "").splitlines() if line.strip()]
 
 
+def _path_variants(path: str) -> tuple[str, str]:
+    normalized = os.path.normcase(os.path.abspath(os.path.expanduser(path)))
+    posix = normalized.replace("\\", "/")
+    return normalized, posix
+
+
 def _normalize_excluded_paths(excluded_paths: str | None) -> list[str]:
     normalized: list[str] = []
     for entry in _split_lines(excluded_paths):
-        try:
-            resolved_path = Path(entry).expanduser().resolve(strict=False)
-            normalized.append(str(resolved_path).casefold())
-        except Exception:
-            normalized.append(Path(entry).expanduser().as_posix().casefold())
+        native, _ = _path_variants(entry)
+        normalized.append(native)
     return normalized
 
 
@@ -60,13 +63,11 @@ def _compile_excluded_patterns(excluded_patterns: str | None) -> list[re.Pattern
 
 
 def _is_path_excluded(path: str, excluded_roots: list[str], excluded_patterns: list[re.Pattern[str]]) -> bool:
-    resolved_path = Path(path).resolve(strict=False)
-    resolved = str(resolved_path).casefold()
-    resolved_posix = resolved_path.as_posix().casefold()
+    resolved, resolved_posix = _path_variants(path)
 
     for root in excluded_roots:
         root_clean = root.rstrip("/\\")
-        if resolved == root_clean or resolved.startswith(root_clean + os.sep.casefold()):
+        if resolved == root_clean or resolved.startswith(root_clean + os.sep):
             return True
         if resolved_posix == root_clean or resolved_posix.startswith(root_clean + "/"):
             return True
@@ -95,100 +96,13 @@ def iter_audio_paths(
             for fn in filenames:
                 file_path = os.path.join(dirpath, fn)
                 ext = os.path.splitext(fn)[1].lower()
-                normalized = str(Path(file_path).resolve())
+                normalized, _ = _path_variants(file_path)
                 if normalized in seen:
                     continue
                 if ext in AUDIO_EXTS and not _is_path_excluded(file_path, excluded_roots, compiled_patterns):
                     seen.add(normalized)
                     paths.append(file_path)
     return paths
-
-
-def iter_audio_paths_with_directory_cache(
-    directories: list[str],
-    *,
-    existing_paths: list[str],
-    cached_directory_mtimes: dict[str, float] | None = None,
-    excluded_paths: str | None = None,
-    excluded_patterns: str | None = None,
-) -> tuple[list[str], dict[str, float]]:
-    excluded_roots = _normalize_excluded_paths(excluded_paths)
-    compiled_patterns = _compile_excluded_patterns(excluded_patterns)
-    cached_directory_mtimes = cached_directory_mtimes or {}
-    seen_paths: set[str] = set()
-    collected_paths: list[str] = []
-    directory_mtimes: dict[str, float] = {}
-
-    subtree_index: dict[str, list[str]] = {}
-    for original in existing_paths:
-        try:
-            resolved_path = Path(original).resolve(strict=False)
-        except Exception:
-            continue
-        current_parent = resolved_path.parent
-        while True:
-            subtree_index.setdefault(str(current_parent), []).append(original)
-            next_parent = current_parent.parent
-            if next_parent == current_parent:
-                break
-            current_parent = next_parent
-
-    def _collect_known_subtree(dir_path: str) -> None:
-        resolved_dir_path = Path(dir_path).resolve(strict=False)
-        resolved_dir = str(resolved_dir_path)
-        for original in subtree_index.get(resolved_dir, []):
-            if original in seen_paths:
-                continue
-            if _is_path_excluded(original, excluded_roots, compiled_patterns):
-                continue
-            seen_paths.add(original)
-            collected_paths.append(original)
-
-    def _walk_dir(dir_path: str) -> None:
-        try:
-            resolved_dir_path = Path(dir_path).resolve(strict=False)
-            resolved_dir = str(resolved_dir_path)
-            dir_mtime = float(os.path.getmtime(resolved_dir))
-        except OSError:
-            return
-
-        directory_mtimes[resolved_dir] = dir_mtime
-        if cached_directory_mtimes.get(resolved_dir) == dir_mtime:
-            _collect_known_subtree(resolved_dir)
-            return
-
-        try:
-            with os.scandir(resolved_dir) as entries:
-                for entry in entries:
-                    entry_path = entry.path
-                    if entry.is_dir(follow_symlinks=False):
-                        if _is_path_excluded(entry_path, excluded_roots, compiled_patterns):
-                            continue
-                        _walk_dir(entry_path)
-                        continue
-
-                    if not entry.is_file(follow_symlinks=False):
-                        continue
-
-                    ext = os.path.splitext(entry.name)[1].lower()
-                    if ext not in AUDIO_EXTS:
-                        continue
-                    normalized = str(Path(entry_path).resolve(strict=False))
-                    if normalized in seen_paths:
-                        continue
-                    if _is_path_excluded(entry_path, excluded_roots, compiled_patterns):
-                        continue
-                    seen_paths.add(normalized)
-                    collected_paths.append(entry_path)
-        except OSError:
-            return
-
-    for root in directories:
-        if not root or not os.path.isdir(root):
-            continue
-        _walk_dir(root)
-
-    return collected_paths, directory_mtimes
 
 
 def preview_audio_path_exclusions(
@@ -210,7 +124,7 @@ def preview_audio_path_exclusions(
             for fn in filenames:
                 file_path = os.path.join(dirpath, fn)
                 ext = os.path.splitext(fn)[1].lower()
-                normalized = str(Path(file_path).resolve())
+                normalized, _ = _path_variants(file_path)
                 if normalized in seen:
                     continue
                 if ext not in AUDIO_EXTS:
@@ -465,7 +379,11 @@ def _read_sidecar(path: str) -> tuple[Optional[str], Optional[str]]:
     return txt, lrc
 
 
-def new_fs_track_from_path(path: str) -> FsTrack | None:
+def new_fs_track_from_path(
+    path: str,
+    *,
+    signature: tuple[float | None, int | None] | None = None,
+) -> FsTrack | None:
     try:
         audio = MutagenFile(path, easy=True)
         if audio is None:
@@ -511,7 +429,7 @@ def new_fs_track_from_path(path: str) -> FsTrack | None:
         txt_lyrics = txt_sidecar or txt_embedded
         lrc_lyrics = lrc_sidecar or lrc_embedded
 
-        modified_time, file_size = get_audio_file_signature(path)
+        modified_time, file_size = signature if signature is not None else get_audio_file_signature(path)
 
         return FsTrack(
             file_path=path,

--- a/src/library/scan_library.py
+++ b/src/library/scan_library.py
@@ -42,9 +42,10 @@ def _normalize_excluded_paths(excluded_paths: str | None) -> list[str]:
     normalized: list[str] = []
     for entry in _split_lines(excluded_paths):
         try:
-            normalized.append(str(Path(entry).expanduser().resolve()).casefold())
+            resolved_path = Path(entry).expanduser().resolve(strict=False)
+            normalized.append(str(resolved_path).casefold())
         except Exception:
-            normalized.append(str(Path(entry).expanduser()).resolve().as_posix().casefold())
+            normalized.append(Path(entry).expanduser().as_posix().casefold())
     return normalized
 
 
@@ -59,8 +60,9 @@ def _compile_excluded_patterns(excluded_patterns: str | None) -> list[re.Pattern
 
 
 def _is_path_excluded(path: str, excluded_roots: list[str], excluded_patterns: list[re.Pattern[str]]) -> bool:
-    resolved = str(Path(path).resolve()).casefold()
-    resolved_posix = Path(path).resolve().as_posix().casefold()
+    resolved_path = Path(path).resolve(strict=False)
+    resolved = str(resolved_path).casefold()
+    resolved_posix = resolved_path.as_posix().casefold()
 
     for root in excluded_roots:
         root_clean = root.rstrip("/\\")
@@ -117,24 +119,24 @@ def iter_audio_paths_with_directory_cache(
     collected_paths: list[str] = []
     directory_mtimes: dict[str, float] = {}
 
-    known_descendants: list[tuple[str, str, str]] = []
+    subtree_index: dict[str, list[str]] = {}
     for original in existing_paths:
         try:
-            resolved = str(Path(original).resolve())
-            resolved_posix = Path(original).resolve().as_posix().casefold()
+            resolved_path = Path(original).resolve(strict=False)
         except Exception:
             continue
-        known_descendants.append((original, resolved.casefold(), resolved_posix))
+        current_parent = resolved_path.parent
+        while True:
+            subtree_index.setdefault(str(current_parent), []).append(original)
+            next_parent = current_parent.parent
+            if next_parent == current_parent:
+                break
+            current_parent = next_parent
 
     def _collect_known_subtree(dir_path: str) -> None:
-        resolved_dir = str(Path(dir_path).resolve())
-        resolved_cf = resolved_dir.casefold().rstrip("/\\")
-        resolved_posix = Path(dir_path).resolve().as_posix().casefold().rstrip("/")
-        for original, file_cf, file_posix in known_descendants:
-            in_win_tree = file_cf == resolved_cf or file_cf.startswith(resolved_cf + os.sep.casefold())
-            in_posix_tree = file_posix == resolved_posix or file_posix.startswith(resolved_posix + "/")
-            if not in_win_tree and not in_posix_tree:
-                continue
+        resolved_dir_path = Path(dir_path).resolve(strict=False)
+        resolved_dir = str(resolved_dir_path)
+        for original in subtree_index.get(resolved_dir, []):
             if original in seen_paths:
                 continue
             if _is_path_excluded(original, excluded_roots, compiled_patterns):
@@ -144,7 +146,8 @@ def iter_audio_paths_with_directory_cache(
 
     def _walk_dir(dir_path: str) -> None:
         try:
-            resolved_dir = str(Path(dir_path).resolve())
+            resolved_dir_path = Path(dir_path).resolve(strict=False)
+            resolved_dir = str(resolved_dir_path)
             dir_mtime = float(os.path.getmtime(resolved_dir))
         except OSError:
             return
@@ -170,7 +173,7 @@ def iter_audio_paths_with_directory_cache(
                     ext = os.path.splitext(entry.name)[1].lower()
                     if ext not in AUDIO_EXTS:
                         continue
-                    normalized = str(Path(entry_path).resolve())
+                    normalized = str(Path(entry_path).resolve(strict=False))
                     if normalized in seen_paths:
                         continue
                     if _is_path_excluded(entry_path, excluded_roots, compiled_patterns):

--- a/src/library/scan_library.py
+++ b/src/library/scan_library.py
@@ -44,6 +44,11 @@ def _path_variants(path: str) -> tuple[str, str]:
     return normalized, posix
 
 
+def _join_normalized_path(dir_normalized: str, filename: str) -> tuple[str, str]:
+    normalized = os.path.normcase(os.path.join(dir_normalized, filename))
+    return normalized, normalized.replace("\\", "/")
+
+
 def _normalize_excluded_paths(excluded_paths: str | None) -> list[tuple[str, str]]:
     normalized: list[tuple[str, str]] = []
     for entry in _split_lines(excluded_paths):
@@ -95,13 +100,27 @@ def iter_audio_paths(
     for root in directories:
         if not root or not os.path.isdir(root):
             continue
-        for dirpath, _, filenames in os.walk(root):
+        for dirpath, dirnames, filenames in os.walk(root):
+            normalized_dir, posix_dir = _path_variants(dirpath)
+            if _is_path_excluded_variants(dirpath, normalized_dir, posix_dir, excluded_roots, compiled_patterns):
+                dirnames[:] = []
+                continue
+
+            kept_dirnames: list[str] = []
+            for dirname in dirnames:
+                child_path = os.path.join(dirpath, dirname)
+                child_normalized, child_posix = _join_normalized_path(normalized_dir, dirname)
+                if _is_path_excluded_variants(child_path, child_normalized, child_posix, excluded_roots, compiled_patterns):
+                    continue
+                kept_dirnames.append(dirname)
+            dirnames[:] = kept_dirnames
+
             for fn in filenames:
                 ext = os.path.splitext(fn)[1].lower()
                 if ext not in AUDIO_EXTS:
                     continue
                 file_path = os.path.join(dirpath, fn)
-                normalized, posix_path = _path_variants(file_path)
+                normalized, posix_path = _join_normalized_path(normalized_dir, fn)
                 if normalized in seen:
                     continue
                 if not _is_path_excluded_variants(file_path, normalized, posix_path, excluded_roots, compiled_patterns):
@@ -125,13 +144,27 @@ def preview_audio_path_exclusions(
     for root in directories:
         if not root or not os.path.isdir(root):
             continue
-        for dirpath, _, filenames in os.walk(root):
+        for dirpath, dirnames, filenames in os.walk(root):
+            normalized_dir, posix_dir = _path_variants(dirpath)
+            if _is_path_excluded_variants(dirpath, normalized_dir, posix_dir, excluded_roots, compiled_patterns):
+                dirnames[:] = []
+                continue
+
+            kept_dirnames: list[str] = []
+            for dirname in dirnames:
+                child_path = os.path.join(dirpath, dirname)
+                child_normalized, child_posix = _join_normalized_path(normalized_dir, dirname)
+                if _is_path_excluded_variants(child_path, child_normalized, child_posix, excluded_roots, compiled_patterns):
+                    continue
+                kept_dirnames.append(dirname)
+            dirnames[:] = kept_dirnames
+
             for fn in filenames:
                 ext = os.path.splitext(fn)[1].lower()
                 if ext not in AUDIO_EXTS:
                     continue
                 file_path = os.path.join(dirpath, fn)
-                normalized, posix_path = _path_variants(file_path)
+                normalized, posix_path = _join_normalized_path(normalized_dir, fn)
                 if normalized in seen:
                     continue
                 seen.add(normalized)

--- a/src/library/scan_library.py
+++ b/src/library/scan_library.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import os
 import logging
+import re
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -32,17 +33,96 @@ AUDIO_EXTS = {".mp3", ".m4a", ".flac", ".ogg", ".opus", ".wav", ".wma", ".asf", 
 ASF_PLAIN_KEYS = ("WM/Lyrics", "LYRICS", "UNSYNCEDLYRICS")
 ASF_SYNCED_KEYS = ("LRCLIB_LRC", "SYNCEDLYRICS")
 
-def iter_audio_paths(directories: list[str]) -> list[str]:
+
+def _split_lines(block: str | None) -> list[str]:
+    return [line.strip() for line in (block or "").splitlines() if line.strip()]
+
+
+def _normalize_excluded_paths(excluded_paths: str | None) -> list[str]:
+    normalized: list[str] = []
+    for entry in _split_lines(excluded_paths):
+        try:
+            normalized.append(str(Path(entry).expanduser().resolve()).casefold())
+        except Exception:
+            normalized.append(str(Path(entry).expanduser()).resolve().as_posix().casefold())
+    return normalized
+
+
+def _compile_excluded_patterns(excluded_patterns: str | None) -> list[re.Pattern[str]]:
+    compiled: list[re.Pattern[str]] = []
+    for pattern in _split_lines(excluded_patterns):
+        try:
+            compiled.append(re.compile(pattern, re.IGNORECASE))
+        except re.error:
+            logger.warning("Ignoring invalid scan exclusion regex: %s", pattern)
+    return compiled
+
+
+def _is_path_excluded(path: str, excluded_roots: list[str], excluded_patterns: list[re.Pattern[str]]) -> bool:
+    resolved = str(Path(path).resolve()).casefold()
+    resolved_posix = Path(path).resolve().as_posix().casefold()
+
+    for root in excluded_roots:
+        root_clean = root.rstrip("/\\")
+        if resolved == root_clean or resolved.startswith(root_clean + os.sep.casefold()):
+            return True
+        if resolved_posix == root_clean or resolved_posix.startswith(root_clean + "/"):
+            return True
+
+    for pattern in excluded_patterns:
+        if pattern.search(path) or pattern.search(resolved_posix):
+            return True
+
+    return False
+
+
+def iter_audio_paths(
+    directories: list[str],
+    *,
+    excluded_paths: str | None = None,
+    excluded_patterns: str | None = None,
+) -> list[str]:
+    excluded_roots = _normalize_excluded_paths(excluded_paths)
+    compiled_patterns = _compile_excluded_patterns(excluded_patterns)
     paths: list[str] = []
     for root in directories:
         if not root or not os.path.isdir(root):
             continue
         for dirpath, _, filenames in os.walk(root):
             for fn in filenames:
+                file_path = os.path.join(dirpath, fn)
                 ext = os.path.splitext(fn)[1].lower()
-                if ext in AUDIO_EXTS:
-                    paths.append(os.path.join(dirpath, fn))
+                if ext in AUDIO_EXTS and not _is_path_excluded(file_path, excluded_roots, compiled_patterns):
+                    paths.append(file_path)
     return paths
+
+
+def preview_audio_path_exclusions(
+    directories: list[str],
+    *,
+    excluded_paths: str | None = None,
+    excluded_patterns: str | None = None,
+) -> tuple[list[str], list[str]]:
+    excluded_roots = _normalize_excluded_paths(excluded_paths)
+    compiled_patterns = _compile_excluded_patterns(excluded_patterns)
+    included: list[str] = []
+    excluded: list[str] = []
+
+    for root in directories:
+        if not root or not os.path.isdir(root):
+            continue
+        for dirpath, _, filenames in os.walk(root):
+            for fn in filenames:
+                file_path = os.path.join(dirpath, fn)
+                ext = os.path.splitext(fn)[1].lower()
+                if ext not in AUDIO_EXTS:
+                    continue
+                if _is_path_excluded(file_path, excluded_roots, compiled_patterns):
+                    excluded.append(file_path)
+                else:
+                    included.append(file_path)
+
+    return included, excluded
 
 def _first(easy, key: str) -> str | None:
     v = easy.get(key)

--- a/src/player/player.py
+++ b/src/player/player.py
@@ -50,6 +50,7 @@ class Player(QObject):
         # Default volume (0.0 - 1.0)
         self._volume_0_to_1: float = 0.7
         self.audio.setVolume(self._volume_0_to_1)
+        self._playback_speed: float = 1.0
 
         # Qt signal forwarding
         self.media.positionChanged.connect(self.positionChanged.emit)
@@ -281,6 +282,7 @@ class Player(QObject):
 
     def set_playback_speed(self, speed: float):
         speed = max(0.25, min(2.0, float(speed)))
+        self._playback_speed = speed
 
         if self._use_mpv and self._mpv:
             self._mpv.set_property("speed", speed)
@@ -295,4 +297,7 @@ class Player(QObject):
     def playback_speed(self) -> float:
         if self._use_mpv and self._mpv:
             return float(self._mpv.get_property("speed") or 1.0)
-        return 1.0
+        try:
+            return float(self.media.playbackRate())
+        except Exception:
+            return float(self._playback_speed)

--- a/src/ui/dialogs/music_folders_dialog.py
+++ b/src/ui/dialogs/music_folders_dialog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+import re
 
 from PySide6.QtWidgets import (
     QCheckBox,
@@ -15,12 +16,14 @@ from PySide6.QtWidgets import (
     QListWidget,
     QMessageBox,
     QPushButton,
+    QTextEdit,
     QVBoxLayout,
 )
 
 from core.lyrics_sidecar import DEFAULT_LYRICS_FILE_PATTERN
 from db.database import get_config, get_directories, set_config, set_directories
 from db.models import Config
+from library.scan_library import preview_audio_path_exclusions
 from ui.theme_tokens import get_available_themes
 
 
@@ -28,7 +31,7 @@ class MusicFoldersDialog(QDialog):
     def __init__(self, app_state, parent=None):
         super().__init__(parent)
         self.setWindowTitle("Settings")
-        self.resize(640, 520)
+        self.resize(700, 700)
         self.app_state = app_state
 
         layout = QVBoxLayout(self)
@@ -93,6 +96,52 @@ class MusicFoldersDialog(QDialog):
         embed_layout.addWidget(self.embed_chk)
         layout.addWidget(embed_box)
 
+        scan_box = QGroupBox("Library Scan")
+        scan_layout = QGridLayout(scan_box)
+
+        self.excluded_paths_edit = QTextEdit()
+        self.excluded_paths_edit.setPlaceholderText(
+            "One path per line.\n"
+            "Example:\n"
+            "D:\\Music\\Podcasts\n"
+            "D:\\Music\\Temporary"
+        )
+        self.add_excluded_path_btn = QPushButton("Add Excluded Path")
+        self.add_excluded_file_btn = QPushButton("Add Excluded File")
+        self.remove_excluded_path_btn = QPushButton("Remove Selected Lines")
+        self.test_exclusions_btn = QPushButton("Test Exclusions")
+        self.excluded_patterns_edit = QTextEdit()
+        self.excluded_patterns_edit.setPlaceholderText(
+            "One regex per line.\n"
+            "Examples:\n"
+            "\\\\Podcasts\\\\\n"
+            "sample|demo\n"
+            "\\.(cue|log)$"
+        )
+
+        scan_layout.addWidget(QLabel("Excluded paths"), 0, 0)
+        scan_layout.addWidget(self.excluded_paths_edit, 1, 0)
+        excluded_paths_btn_row = QHBoxLayout()
+        excluded_paths_btn_row.addWidget(self.add_excluded_path_btn)
+        excluded_paths_btn_row.addWidget(self.add_excluded_file_btn)
+        excluded_paths_btn_row.addWidget(self.remove_excluded_path_btn)
+        excluded_paths_btn_row.addWidget(self.test_exclusions_btn)
+        excluded_paths_btn_row.addStretch(1)
+        scan_layout.addLayout(excluded_paths_btn_row, 2, 0)
+        scan_layout.addWidget(QLabel("Excluded regex patterns"), 0, 1)
+        scan_layout.addWidget(self.excluded_patterns_edit, 1, 1)
+        self.regex_validation_label = QLabel("")
+        self.regex_validation_label.setObjectName("SettingsValidationHint")
+        self.regex_validation_label.setVisible(False)
+        scan_layout.addWidget(self.regex_validation_label, 2, 1)
+
+        scan_hint = QLabel(
+            "Paths skip exact files or entire folders. Regex patterns are matched against the full file path."
+        )
+        scan_hint.setWordWrap(True)
+        scan_layout.addWidget(scan_hint, 3, 0, 1, 2)
+        layout.addWidget(scan_box)
+
         self.save_btn = QPushButton("Save")
         layout.addWidget(self.save_btn)
 
@@ -104,6 +153,11 @@ class MusicFoldersDialog(QDialog):
         self.browse_output_btn.clicked.connect(self._browse_output_dir)
         self.clear_output_btn.clicked.connect(lambda: self.output_dir_edit.setText(""))
         self.save_sidecars_chk.toggled.connect(self._update_export_fields_enabled)
+        self.add_excluded_path_btn.clicked.connect(self._add_excluded_path)
+        self.add_excluded_file_btn.clicked.connect(self._add_excluded_file)
+        self.remove_excluded_path_btn.clicked.connect(self._remove_selected_excluded_path_lines)
+        self.test_exclusions_btn.clicked.connect(self._test_exclusions)
+        self.excluded_patterns_edit.textChanged.connect(self._validate_regex_patterns)
 
     def _load(self):
         self.list_widget.clear()
@@ -117,7 +171,10 @@ class MusicFoldersDialog(QDialog):
         self.output_dir_edit.setText(config.lyrics_output_dir)
         self.pattern_edit.setText(config.lyrics_file_pattern or DEFAULT_LYRICS_FILE_PATTERN)
         self.embed_chk.setChecked(config.try_embed_lyrics)
+        self.excluded_paths_edit.setPlainText(config.scan_excluded_paths)
+        self.excluded_patterns_edit.setPlainText(config.scan_excluded_patterns)
         self._update_export_fields_enabled()
+        self._validate_regex_patterns()
 
     def add_folder(self):
         path = QFileDialog.getExistingDirectory(self, "Select Music Folder")
@@ -138,6 +195,102 @@ class MusicFoldersDialog(QDialog):
         path = QFileDialog.getExistingDirectory(self, "Select Lyrics Download Directory")
         if path:
             self.output_dir_edit.setText(path)
+
+    def _add_excluded_path(self):
+        path = QFileDialog.getExistingDirectory(self, "Select Excluded Folder")
+        if not path:
+            return
+
+        self._append_excluded_path(path)
+
+    def _add_excluded_file(self):
+        path, _ = QFileDialog.getOpenFileName(self, "Select Excluded File")
+        if not path:
+            return
+        self._append_excluded_path(path)
+
+    def _append_excluded_path(self, path: str):
+        existing = [line.strip() for line in self.excluded_paths_edit.toPlainText().splitlines() if line.strip()]
+        if path not in existing:
+            existing.append(path)
+            self.excluded_paths_edit.setPlainText("\n".join(existing))
+
+    def _remove_selected_excluded_path_lines(self):
+        cursor = self.excluded_paths_edit.textCursor()
+        if not cursor.hasSelection():
+            return
+
+        start_block = self.excluded_paths_edit.document().findBlock(cursor.selectionStart()).blockNumber()
+        end_block = self.excluded_paths_edit.document().findBlock(max(cursor.selectionEnd() - 1, cursor.selectionStart())).blockNumber()
+
+        lines = self.excluded_paths_edit.toPlainText().splitlines()
+        kept = [line for idx, line in enumerate(lines) if idx < start_block or idx > end_block]
+        self.excluded_paths_edit.setPlainText("\n".join(kept))
+
+    def _validate_regex_patterns(self):
+        invalid: list[str] = []
+        for line in self.excluded_patterns_edit.toPlainText().splitlines():
+            pattern = line.strip()
+            if not pattern:
+                continue
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                invalid.append(f"{pattern}: {exc}")
+
+        if invalid:
+            self.regex_validation_label.setProperty("validationState", "error")
+            self.regex_validation_label.setText("Invalid regex:\n" + "\n".join(invalid[:3]))
+            self.regex_validation_label.setVisible(True)
+            self.save_btn.setEnabled(False)
+        else:
+            self.regex_validation_label.setProperty("validationState", "success")
+            self.regex_validation_label.setText("Regex patterns look valid.")
+            self.regex_validation_label.setVisible(bool(self.excluded_patterns_edit.toPlainText().strip()))
+            self.save_btn.setEnabled(True)
+
+        self.regex_validation_label.style().unpolish(self.regex_validation_label)
+        self.regex_validation_label.style().polish(self.regex_validation_label)
+        self.regex_validation_label.update()
+
+    def _test_exclusions(self):
+        self._validate_regex_patterns()
+        if not self.save_btn.isEnabled():
+            QMessageBox.warning(
+                self,
+                "Invalid regex",
+                "Please fix the invalid regex patterns before testing exclusions.",
+            )
+            return
+
+        folders = [self.list_widget.item(i).text() for i in range(self.list_widget.count())]
+        if not folders:
+            QMessageBox.warning(self, "No folders", "Please add at least one music folder.")
+            return
+
+        included, excluded = preview_audio_path_exclusions(
+            folders,
+            excluded_paths=self.excluded_paths_edit.toPlainText().strip(),
+            excluded_patterns=self.excluded_patterns_edit.toPlainText().strip(),
+        )
+
+        total = len(included) + len(excluded)
+        lines = [
+            f"Audio files found: {total}",
+            f"Included in scan: {len(included)}",
+            f"Excluded from scan: {len(excluded)}",
+        ]
+
+        if excluded:
+            sample_count = min(10, len(excluded))
+            lines.append("")
+            lines.append(f"Examples of excluded files ({sample_count} shown):")
+            lines.extend(excluded[:sample_count])
+        else:
+            lines.append("")
+            lines.append("No audio files are excluded by the current rules.")
+
+        QMessageBox.information(self, "Exclusion Preview", "\n".join(lines))
 
     def _update_export_fields_enabled(self):
         enabled = self.save_sidecars_chk.isChecked()
@@ -160,6 +313,8 @@ class MusicFoldersDialog(QDialog):
             try_embed_lyrics=self.embed_chk.isChecked(),
             lyrics_output_dir=self.output_dir_edit.text().strip(),
             lyrics_file_pattern=self.pattern_edit.text().strip() or DEFAULT_LYRICS_FILE_PATTERN,
+            scan_excluded_paths=self.excluded_paths_edit.toPlainText().strip(),
+            scan_excluded_patterns=self.excluded_patterns_edit.toPlainText().strip(),
         )
 
         set_directories(self.app_state.db, folders)

--- a/src/ui/dialogs/music_folders_dialog.py
+++ b/src/ui/dialogs/music_folders_dialog.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+import os
 import re
 
 from PySide6.QtWidgets import (
@@ -34,6 +35,7 @@ class MusicFoldersDialog(QDialog):
         self.setWindowTitle("Settings")
         self.resize(700, 700)
         self.app_state = app_state
+        self._last_browse_dir = os.path.expanduser("~")
 
         layout = QVBoxLayout(self)
 
@@ -186,11 +188,18 @@ class MusicFoldersDialog(QDialog):
         self.reaction_delay_spin.setValue(int(config.reaction_delay_ms or 0))
         self.excluded_paths_edit.setPlainText(config.scan_excluded_paths)
         self.excluded_patterns_edit.setPlainText(config.scan_excluded_patterns)
+        directories = get_directories(self.app_state.db)
+        if config.lyrics_output_dir and os.path.isdir(config.lyrics_output_dir):
+            self._last_browse_dir = config.lyrics_output_dir
+        elif directories:
+            first_directory = directories[0]
+            if os.path.isdir(first_directory):
+                self._last_browse_dir = first_directory
         self._update_export_fields_enabled()
         self._validate_regex_patterns()
 
     def add_folder(self):
-        path = QFileDialog.getExistingDirectory(self, "Select Music Folder")
+        path = self._pick_directory("Select Music Folder")
         if not path:
             return
 
@@ -205,22 +214,61 @@ class MusicFoldersDialog(QDialog):
             self.list_widget.takeItem(self.list_widget.row(item))
 
     def _browse_output_dir(self):
-        path = QFileDialog.getExistingDirectory(self, "Select Lyrics Download Directory")
+        path = self._pick_directory("Select Lyrics Download Directory", self.output_dir_edit.text().strip())
         if path:
             self.output_dir_edit.setText(path)
 
     def _add_excluded_path(self):
-        path = QFileDialog.getExistingDirectory(self, "Select Excluded Folder")
+        path = self._pick_directory("Select Excluded Folder")
         if not path:
             return
 
         self._append_excluded_path(path)
 
     def _add_excluded_file(self):
-        path, _ = QFileDialog.getOpenFileName(self, "Select Excluded File")
+        path = self._pick_file("Select Excluded File")
         if not path:
             return
         self._append_excluded_path(path)
+
+    def _dialog_start_dir(self, preferred: str = "") -> str:
+        preferred = (preferred or "").strip()
+        if preferred:
+            if os.path.isdir(preferred):
+                return preferred
+            parent = os.path.dirname(preferred)
+            if parent and os.path.isdir(parent):
+                return parent
+        if os.path.isdir(self._last_browse_dir):
+            return self._last_browse_dir
+        return os.path.expanduser("~")
+
+    def _pick_directory(self, title: str, preferred: str = "") -> str:
+        dialog = QFileDialog(self, title, self._dialog_start_dir(preferred))
+        dialog.setFileMode(QFileDialog.FileMode.Directory)
+        dialog.setOption(QFileDialog.Option.ShowDirsOnly, True)
+        dialog.setOption(QFileDialog.Option.DontUseNativeDialog, True)
+        dialog.setOption(QFileDialog.Option.DontUseCustomDirectoryIcons, True)
+        if dialog.exec():
+            selected = dialog.selectedFiles()
+            if selected:
+                path = selected[0]
+                self._last_browse_dir = path
+                return path
+        return ""
+
+    def _pick_file(self, title: str, preferred: str = "") -> str:
+        dialog = QFileDialog(self, title, self._dialog_start_dir(preferred))
+        dialog.setFileMode(QFileDialog.FileMode.ExistingFile)
+        dialog.setOption(QFileDialog.Option.DontUseNativeDialog, True)
+        dialog.setOption(QFileDialog.Option.DontUseCustomDirectoryIcons, True)
+        if dialog.exec():
+            selected = dialog.selectedFiles()
+            if selected:
+                path = selected[0]
+                self._last_browse_dir = os.path.dirname(path) or self._last_browse_dir
+                return path
+        return ""
 
     def _append_excluded_path(self, path: str):
         existing = [line.strip() for line in self.excluded_paths_edit.toPlainText().splitlines() if line.strip()]

--- a/src/ui/dialogs/music_folders_dialog.py
+++ b/src/ui/dialogs/music_folders_dialog.py
@@ -16,6 +16,7 @@ from PySide6.QtWidgets import (
     QListWidget,
     QMessageBox,
     QPushButton,
+    QSpinBox,
     QTextEdit,
     QVBoxLayout,
 )
@@ -90,10 +91,21 @@ class MusicFoldersDialog(QDialog):
         layout.addWidget(lyrics_box)
 
         embed_box = QGroupBox("Audio File")
-        embed_layout = QVBoxLayout(embed_box)
+        embed_layout = QGridLayout(embed_box)
         self.embed_chk = QCheckBox("Embed lyrics into the audio file")
         self.embed_chk.setChecked(True)
-        embed_layout.addWidget(self.embed_chk)
+        embed_layout.addWidget(self.embed_chk, 0, 0, 1, 2)
+
+        self.reaction_delay_spin = QSpinBox()
+        self.reaction_delay_spin.setRange(-2000, 2000)
+        self.reaction_delay_spin.setSingleStep(10)
+        self.reaction_delay_spin.setSuffix(" ms")
+        embed_layout.addWidget(QLabel("Reaction delay"), 1, 0)
+        embed_layout.addWidget(self.reaction_delay_spin, 1, 1)
+
+        reaction_hint = QLabel("Negative values stamp earlier. Positive values stamp later.")
+        reaction_hint.setWordWrap(True)
+        embed_layout.addWidget(reaction_hint, 2, 0, 1, 2)
         layout.addWidget(embed_box)
 
         scan_box = QGroupBox("Library Scan")
@@ -171,6 +183,7 @@ class MusicFoldersDialog(QDialog):
         self.output_dir_edit.setText(config.lyrics_output_dir)
         self.pattern_edit.setText(config.lyrics_file_pattern or DEFAULT_LYRICS_FILE_PATTERN)
         self.embed_chk.setChecked(config.try_embed_lyrics)
+        self.reaction_delay_spin.setValue(int(config.reaction_delay_ms or 0))
         self.excluded_paths_edit.setPlainText(config.scan_excluded_paths)
         self.excluded_patterns_edit.setPlainText(config.scan_excluded_patterns)
         self._update_export_fields_enabled()
@@ -315,6 +328,7 @@ class MusicFoldersDialog(QDialog):
             lyrics_file_pattern=self.pattern_edit.text().strip() or DEFAULT_LYRICS_FILE_PATTERN,
             scan_excluded_paths=self.excluded_paths_edit.toPlainText().strip(),
             scan_excluded_patterns=self.excluded_patterns_edit.toPlainText().strip(),
+            reaction_delay_ms=int(self.reaction_delay_spin.value()),
         )
 
         set_directories(self.app_state.db, folders)

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -215,6 +215,7 @@ class MainWindow(QMainWindow):
         self.player_bar = PlayerBar(self.app_state.player, self)
         self.layout.addWidget(self.player_bar)
         self.player_bar.set_prev_next_handlers(self.play_prev, self.play_next)
+        self.lyrics_view.set_reaction_delay_ms(get_config(self.app_state.db).reaction_delay_ms)
 
         # --- Scan progress (pretty + hidden when idle) ---
         self.scan_row = QWidget()
@@ -304,9 +305,11 @@ class MainWindow(QMainWindow):
         before = get_config(self.app_state.db).theme_mode
         dlg = MusicFoldersDialog(self.app_state, self)
         if dlg.exec():
-            after = get_config(self.app_state.db).theme_mode
+            updated_config = get_config(self.app_state.db)
+            after = updated_config.theme_mode
             if after != before:
                 self._apply_theme(after)
+            self.lyrics_view.set_reaction_delay_ms(updated_config.reaction_delay_ms)
             self._apply_track_filters()
 
     def open_about_modal(self):

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -340,7 +340,13 @@ class MainWindow(QMainWindow):
         self.scan_details.setText(f"Preparing a scan across {len(directories)} folder(s)…")
         self.btn_cancel_scan.setEnabled(True)
 
-        self.scanner = LibraryScanner(self.app_state.db_path, directories)
+        config = get_config(self.app_state.db)
+        self.scanner = LibraryScanner(
+            self.app_state.db_path,
+            directories,
+            excluded_paths=config.scan_excluded_paths,
+            excluded_patterns=config.scan_excluded_patterns,
+        )
         self.scanner.progress_signal.connect(self._update_scan_progress)
         self.scanner.finished_signal.connect(self._scan_finished)
         self.scanner.start()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -3,7 +3,7 @@ from PySide6.QtWidgets import (
     QTabWidget, QProgressBar, QMessageBox, QLineEdit, QHBoxLayout, QCheckBox, QSplitter, QBoxLayout, QPushButton, QApplication
 )
 from PySide6.QtCore import Qt, QTimer
-from PySide6.QtGui import QShortcut, QKeySequence
+from PySide6.QtGui import QCloseEvent, QShortcut, QKeySequence
 import os
 
 from dataclasses import replace
@@ -39,6 +39,11 @@ class MainWindow(QMainWindow):
         self._queue_ids: list[int] = []
         self._queue_index: int = -1
         self._refresh_default_label = "Global Actions"
+        self._pending_playback_speed: float | None = None
+        self._playback_speed_save_timer = QTimer(self)
+        self._playback_speed_save_timer.setSingleShot(True)
+        self._playback_speed_save_timer.setInterval(350)
+        self._playback_speed_save_timer.timeout.connect(self._flush_playback_speed)
 
         # --- Player signals ---
         if self.app_state.player:
@@ -291,6 +296,10 @@ class MainWindow(QMainWindow):
     def resizeEvent(self, event):
         super().resizeEvent(event)
         self._update_responsive_layout()
+
+    def closeEvent(self, event: QCloseEvent) -> None:
+        self._flush_playback_speed()
+        super().closeEvent(event)
 
     # ------------------ filters ------------------
     def _apply_track_filters(self):
@@ -686,8 +695,15 @@ class MainWindow(QMainWindow):
         self.player_bar.set_playback_speed_value(speed)
 
     def _persist_playback_speed(self, speed: float) -> None:
+        self._pending_playback_speed = float(speed)
+        self._playback_speed_save_timer.start()
+
+    def _flush_playback_speed(self) -> None:
+        if self._pending_playback_speed is None:
+            return
         config = get_config(self.app_state.db)
-        set_config(self.app_state.db, replace(config, playback_speed=float(speed)))
+        set_config(self.app_state.db, replace(config, playback_speed=float(self._pending_playback_speed)))
+        self._pending_playback_speed = None
 
     def _play_selected_or_current(self):
         tid = self.track_list.selected_track_id()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -6,7 +6,9 @@ from PySide6.QtCore import Qt, QTimer
 from PySide6.QtGui import QShortcut, QKeySequence
 import os
 
-from db.database import get_config, get_directories, get_track_by_id
+from dataclasses import replace
+
+from db.database import get_config, get_directories, get_track_by_id, set_config
 from core.lyrics_sidecar import export_lyrics_sidecars
 from ui.workers.library_scanner import LibraryScanner
 from ui.widgets.track_list_widget import TrackListWidget
@@ -215,7 +217,9 @@ class MainWindow(QMainWindow):
         self.player_bar = PlayerBar(self.app_state.player, self)
         self.layout.addWidget(self.player_bar)
         self.player_bar.set_prev_next_handlers(self.play_prev, self.play_next)
+        self.player_bar.playbackSpeedChanged.connect(self._persist_playback_speed)
         self.lyrics_view.set_reaction_delay_ms(get_config(self.app_state.db).reaction_delay_ms)
+        self._apply_saved_playback_speed()
 
         # --- Scan progress (pretty + hidden when idle) ---
         self.scan_row = QWidget()
@@ -670,6 +674,20 @@ class MainWindow(QMainWindow):
                 self.app_state.notify(f"Failed to embed lyrics: {exc}", "error")
             else:
                 self.statusBar().showMessage("Lyrics embedded into the audio file.", 3000)
+
+    def _apply_saved_playback_speed(self) -> None:
+        config = get_config(self.app_state.db)
+        speed = float(config.playback_speed or 1.0)
+        if self.app_state.player and hasattr(self.app_state.player, "set_playback_speed"):
+            try:
+                self.app_state.player.set_playback_speed(speed)
+            except Exception:
+                speed = 1.0
+        self.player_bar.set_playback_speed_value(speed)
+
+    def _persist_playback_speed(self, speed: float) -> None:
+        config = get_config(self.app_state.db)
+        set_config(self.app_state.db, replace(config, playback_speed=float(speed)))
 
     def _play_selected_or_current(self):
         tid = self.track_list.selected_track_id()

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -401,7 +401,7 @@ class MainWindow(QMainWindow):
 
         if ok:
             self._apply_track_filters()
-            self.app_state.notify("Library scan finished successfully.", "success")
+            self.app_state.notify(msg or "Library scan finished successfully.", "success")
             self._set_tool_feedback(self.btn_refresh, "success")
         else:
             if "cancel" in (msg or "").lower():

--- a/src/ui/player_bar.py
+++ b/src/ui/player_bar.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import base64
 from pathlib import Path
 
-from PySide6.QtCore import QSize, Qt
+from PySide6.QtCore import QSize, Qt, Signal
 from PySide6.QtGui import QColor, QFont, QLinearGradient, QPainter, QPixmap
 from PySide6.QtWidgets import (
     QComboBox,
@@ -187,6 +187,8 @@ class SeekSlider(QSlider):
 
 
 class PlayerBar(QWidget):
+    playbackSpeedChanged = Signal(float)
+
     def __init__(self, player, parent=None):
         super().__init__(parent)
         self.player = player
@@ -194,6 +196,7 @@ class PlayerBar(QWidget):
         self._dragging = False
         self._duration_ms = 0
         self._is_playing = False
+        self._speed_step = 0.05
         self.setObjectName("PlayerBar")
         self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Fixed)
 
@@ -310,17 +313,44 @@ class PlayerBar(QWidget):
         self.lbl_speed = QLabel("Speed")
         self.lbl_speed.setObjectName("MetaLabel")
 
+        speed_row = QHBoxLayout()
+        set_layout_spacing(speed_row, margins=0, spacing=SPACE_2)
+
+        self.btn_speed_down = QToolButton()
+        self.btn_speed_down.setObjectName("SpeedAdjustButton")
+        self.btn_speed_down.setText("-")
+        self.btn_speed_down.setToolTip("Decrease playback speed by 0.05x")
+
         self.cmb_speed = QComboBox()
         self.cmb_speed.setObjectName("SpeedCombo")
         self.cmb_speed.setToolTip("Playback speed")
         self.cmb_speed.setAccessibleName("Playback speed")
-        self._speed_items = [("1.0x", 1.0), ("0.75x", 0.75), ("0.5x", 0.5), ("0.25x", 0.25)]
+        self.cmb_speed.setEditable(True)
+        self.cmb_speed.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
+        self._speed_items = [
+            ("1.0x", 1.0),
+            ("0.9x", 0.9),
+            ("0.8x", 0.8),
+            ("0.75x", 0.75),
+            ("0.5x", 0.5),
+            ("0.25x", 0.25),
+        ]
         for label, speed in self._speed_items:
             self.cmb_speed.addItem(label, speed)
         self.cmb_speed.setCurrentIndex(0)
+        self.cmb_speed.lineEdit().setPlaceholderText("Custom")
+
+        self.btn_speed_up = QToolButton()
+        self.btn_speed_up.setObjectName("SpeedAdjustButton")
+        self.btn_speed_up.setText("+")
+        self.btn_speed_up.setToolTip("Increase playback speed by 0.05x")
+
+        speed_row.addWidget(self.btn_speed_down)
+        speed_row.addWidget(self.cmb_speed, 1)
+        speed_row.addWidget(self.btn_speed_up)
 
         right_layout.addWidget(self.lbl_speed)
-        right_layout.addWidget(self.cmb_speed)
+        right_layout.addLayout(speed_row)
 
         left_slot = QWidget()
         left_slot_layout = QHBoxLayout(left_slot)
@@ -353,7 +383,10 @@ class PlayerBar(QWidget):
         self.slider.sliderPressed.connect(self._on_slider_pressed)
         self.slider.sliderReleased.connect(self._on_slider_released)
         self.slider.sliderMoved.connect(self._on_slider_moved)
-        self.cmb_speed.currentIndexChanged.connect(self._on_speed_changed)
+        self.cmb_speed.activated.connect(self._on_speed_preset_selected)
+        self.cmb_speed.lineEdit().editingFinished.connect(self._on_custom_speed_committed)
+        self.btn_speed_down.clicked.connect(lambda: self._step_speed(-self._speed_step))
+        self.btn_speed_up.clicked.connect(lambda: self._step_speed(self._speed_step))
 
         if self.player:
             self.player.trackChanged.connect(self._on_track_changed)
@@ -370,6 +403,9 @@ class PlayerBar(QWidget):
     def set_prev_next_handlers(self, prev_fn, next_fn):
         self.btn_prev.clicked.connect(prev_fn)
         self.btn_next.clicked.connect(next_fn)
+
+    def set_playback_speed_value(self, speed: float) -> None:
+        self._set_speed_combo_value(self._normalize_speed(speed))
 
     def set_compact_mode(self, compact: bool):
         self.setProperty("compact", compact)
@@ -394,15 +430,54 @@ class PlayerBar(QWidget):
         else:
             self.lbl_cover.setPixmap(_artwork_pixmap("?", None, None, cover_size))
 
-    def _on_speed_changed(self, _index: int):
-        if not self.player:
-            return
-        speed = float(self.cmb_speed.currentData() or 1.0)
-        if hasattr(self.player, "set_playback_speed"):
+    def _format_speed_label(self, speed: float) -> str:
+        rendered = f"{float(speed):.2f}".rstrip("0").rstrip(".")
+        if "." not in rendered:
+            rendered += ".0"
+        return f"{rendered}x"
+
+    def _normalize_speed(self, speed: float) -> float:
+        return max(0.25, min(2.0, round(float(speed), 2)))
+
+    def _apply_speed(self, speed: float) -> None:
+        normalized = self._normalize_speed(speed)
+        if self.player and hasattr(self.player, "set_playback_speed"):
             try:
-                self.player.set_playback_speed(speed)
+                self.player.set_playback_speed(normalized)
             except Exception:
-                pass
+                self._sync_speed_from_player()
+                return
+        self._set_speed_combo_value(normalized)
+        self.playbackSpeedChanged.emit(normalized)
+
+    def _on_speed_preset_selected(self, index: int):
+        speed = self.cmb_speed.itemData(index)
+        if speed is None:
+            return
+        self._apply_speed(float(speed))
+
+    def _on_custom_speed_committed(self):
+        raw = (self.cmb_speed.currentText() or "").strip().lower().replace("x", "")
+        if not raw:
+            self._sync_speed_from_player()
+            return
+
+        try:
+            speed = float(raw)
+        except ValueError:
+            self._sync_speed_from_player()
+            return
+
+        self._apply_speed(speed)
+
+    def _step_speed(self, delta: float) -> None:
+        current = 1.0
+        if self.player and hasattr(self.player, "playback_speed"):
+            try:
+                current = float(self.player.playback_speed() or 1.0)
+            except Exception:
+                current = 1.0
+        self._apply_speed(current + delta)
 
     def _sync_speed_from_player(self):
         if not self.player or not hasattr(self.player, "playback_speed"):
@@ -412,10 +487,21 @@ class PlayerBar(QWidget):
         except Exception:
             speed = 1.0
 
+        self._set_speed_combo_value(speed)
+
+    def _set_speed_combo_value(self, speed: float):
         for idx in range(self.cmb_speed.count()):
             if abs(float(self.cmb_speed.itemData(idx)) - speed) < 0.001:
+                self.cmb_speed.blockSignals(True)
                 self.cmb_speed.setCurrentIndex(idx)
+                self.cmb_speed.lineEdit().setText(self.cmb_speed.itemText(idx))
+                self.cmb_speed.blockSignals(False)
                 return
+
+        self.cmb_speed.blockSignals(True)
+        self.cmb_speed.setCurrentIndex(-1)
+        self.cmb_speed.lineEdit().setText(self._format_speed_label(speed))
+        self.cmb_speed.blockSignals(False)
 
     def _on_slider_pressed(self):
         self._dragging = True

--- a/src/ui/qss/app.qss
+++ b/src/ui/qss/app.qss
@@ -164,6 +164,26 @@ QLabel#OnboardingSteps {
     color: {{color-text}};
 }
 
+QLabel#SettingsValidationHint {
+    border-radius: {{radius-md}};
+    padding: 6px {{space-3}};
+    background: {{color-validation-bg}};
+    color: {{color-text}};
+    border: 1px solid {{color-validation-border}};
+}
+
+QLabel#SettingsValidationHint[validationState="error"] {
+    background: {{color-error-bg}};
+    color: {{color-error-text}};
+    border-color: {{color-error-border}};
+}
+
+QLabel#SettingsValidationHint[validationState="success"] {
+    background: {{color-success-bg}};
+    color: {{color-success-text}};
+    border-color: {{color-success-border}};
+}
+
 QTabWidget#MainTabs::pane {
     border: 1px solid {{color-border-strong}};
     border-radius: {{radius-xl}};

--- a/src/ui/qss/player_bar.qss
+++ b/src/ui/qss/player_bar.qss
@@ -161,3 +161,20 @@ QComboBox#SpeedCombo::drop-down {
     border: none;
     width: 18px;
 }
+
+QToolButton#SpeedAdjustButton {
+    background: {{color-bg-control}};
+    border: 1px solid {{color-border}};
+    border-radius: {{radius-md}};
+    min-width: 28px;
+    min-height: 28px;
+    font-size: 14px;
+    font-weight: 600;
+    padding: 2px;
+}
+
+QToolButton#SpeedAdjustButton:hover {
+    border-color: {{color-accent}};
+    background: {{color-bg-elevated}};
+    color: {{color-accent}};
+}

--- a/src/ui/widgets/lyrics_editor_widget.py
+++ b/src/ui/widgets/lyrics_editor_widget.py
@@ -147,6 +147,7 @@ class LyricsEditorWidget(QWidget):
         self._default_button_text: dict[QPushButton, str] = {}
         self._publish_synced_available = False
         self._publish_plain_available = False
+        self._reaction_delay_ms: int = 0
 
         root = QVBoxLayout(self)
         set_layout_spacing(root, margins=SPACE_3, spacing=SPACE_2)
@@ -258,6 +259,9 @@ class LyricsEditorWidget(QWidget):
         self._refresh_row_styles()
 
         self.table.scrollToItem(self.table.item(idx, 1), self.table.ScrollHint.PositionAtCenter)
+
+    def set_reaction_delay_ms(self, reaction_delay_ms: int) -> None:
+        self._reaction_delay_ms = int(reaction_delay_ms or 0)
 
     def _apply_styles(self):
         self.setStyleSheet(load_stylesheet("lyrics_editor.qss"))
@@ -558,7 +562,7 @@ class LyricsEditorWidget(QWidget):
         if not it_time:
             return
 
-        ms = int(self._current_pos_ms)
+        ms = max(0, int(self._current_pos_ms) + int(self._reaction_delay_ms))
         self.table.blockSignals(True)
         it_time.setData(TIMESTAMP_MS_ROLE, ms)
         it_time.setData(TIMESTAMP_VALID_ROLE, True)
@@ -574,7 +578,14 @@ class LyricsEditorWidget(QWidget):
                 state="error",
             )
         else:
-            self._set_validation_message("Snapped selected line to current playback time.", state="success")
+            if self._reaction_delay_ms:
+                direction = "earlier" if self._reaction_delay_ms < 0 else "later"
+                self._set_validation_message(
+                    f"Snapped line using {abs(self._reaction_delay_ms)} ms reaction delay ({direction}).",
+                    state="success",
+                )
+            else:
+                self._set_validation_message("Snapped selected line to current playback time.", state="success")
         self._update_save_enabled()
         self._refresh_row_styles()
 

--- a/src/ui/workers/library_scanner.py
+++ b/src/ui/workers/library_scanner.py
@@ -86,14 +86,9 @@ class LibraryScanner(QThread):
                     updated += 1
 
                 if len(batch) >= 100:
-                    db.execute("BEGIN")
-                    try:
+                    with db:
                         delete_tracks_by_paths(db, pending_replacements, commit=False)
                         add_tracks(db, batch, commit=False)
-                        db.commit()
-                    except Exception:
-                        db.rollback()
-                        raise
                     batch.clear()
                     pending_replacements.clear()
                     self.progress_signal.emit(scanned, total, p, time.perf_counter() - started_at)
@@ -102,14 +97,9 @@ class LibraryScanner(QThread):
                     self.progress_signal.emit(scanned, total, p, time.perf_counter() - started_at)
 
             if batch or pending_replacements:
-                db.execute("BEGIN")
-                try:
+                with db:
                     delete_tracks_by_paths(db, pending_replacements, commit=False)
                     add_tracks(db, batch, commit=False)
-                    db.commit()
-                except Exception:
-                    db.rollback()
-                    raise
 
             if removed_paths:
                 delete_tracks_by_paths(db, removed_paths)

--- a/src/ui/workers/library_scanner.py
+++ b/src/ui/workers/library_scanner.py
@@ -63,6 +63,8 @@ class LibraryScanner(QThread):
                 if self.isInterruptionRequested():
                     if db is not None:
                         db.rollback()
+                        db.close()
+                        db = None
                     self.finished_signal.emit(False, "Library scan cancelled.")
                     return
 

--- a/src/ui/workers/library_scanner.py
+++ b/src/ui/workers/library_scanner.py
@@ -3,8 +3,21 @@ import sqlite3
 import time
 from PySide6.QtCore import QThread, Signal
 
-from library.scan_library import iter_audio_paths, new_fs_track_from_path
-from db.database import clean_library, add_tracks  # or add_tracks_bulk
+from library.scan_library import (
+    get_audio_file_signature,
+    iter_audio_paths_with_directory_cache,
+    new_fs_track_from_path,
+)
+from db.database import (
+    add_tracks,
+    delete_tracks_by_paths,
+    get_library_file_index,
+    get_scan_cache_meta,
+    get_scan_directory_index,
+    prune_library,
+    replace_scan_directory_index,
+    set_scan_cache_meta,
+)
 
 class LibraryScanner(QThread):
     progress_signal = Signal(int, int, str, float)     # scanned, total, current path, elapsed seconds
@@ -28,19 +41,36 @@ class LibraryScanner(QThread):
         db = None
         started_at = time.perf_counter()
         try:
-            paths = iter_audio_paths(
+            # IMPORTANT: open db connection inside this thread
+            db = sqlite3.connect(self.db_path)
+            db.row_factory = sqlite3.Row
+
+            existing_index = get_library_file_index(db)
+            previous_excluded_paths = get_scan_cache_meta(db, "excluded_paths")
+            previous_excluded_patterns = get_scan_cache_meta(db, "excluded_patterns")
+            cache_compatible = (
+                previous_excluded_paths == self.excluded_paths
+                and previous_excluded_patterns == self.excluded_patterns
+            )
+            cached_directory_mtimes = get_scan_directory_index(db) if cache_compatible else {}
+            paths, directory_mtimes = iter_audio_paths_with_directory_cache(
                 self.directories,
+                existing_paths=list(existing_index.keys()),
+                cached_directory_mtimes=cached_directory_mtimes,
                 excluded_paths=self.excluded_paths,
                 excluded_patterns=self.excluded_patterns,
             )
             total = len(paths)
             scanned = 0
+            unchanged = 0
+            updated = 0
+            removed = 0
 
-            # IMPORTANT: open db connection inside this thread
-            db = sqlite3.connect(self.db_path)
-            db.row_factory = sqlite3.Row
-
-            clean_library(db)
+            current_path_set = set(paths)
+            removed_paths = [path for path in existing_index.keys() if path not in current_path_set]
+            if removed_paths:
+                delete_tracks_by_paths(db, removed_paths)
+                removed = len(removed_paths)
 
             batch = []
             for p in paths:
@@ -50,11 +80,22 @@ class LibraryScanner(QThread):
                     self.finished_signal.emit(False, "Library scan cancelled.")
                     return
 
-                t = new_fs_track_from_path(p)
                 scanned += 1
+                signature = get_audio_file_signature(p)
+                if existing_index.get(p) == signature:
+                    unchanged += 1
+                    if scanned % 200 == 0:
+                        self.progress_signal.emit(scanned, total, p, time.perf_counter() - started_at)
+                    continue
+
+                if p in existing_index:
+                    delete_tracks_by_paths(db, [p])
+
+                t = new_fs_track_from_path(p)
 
                 if t is not None:
                     batch.append(t)
+                    updated += 1
 
                 if len(batch) >= 100:
                     add_tracks(db, batch)   # later replace with add_tracks_bulk
@@ -67,9 +108,16 @@ class LibraryScanner(QThread):
             if batch:
                 add_tracks(db, batch)
 
+            prune_library(db)
+            replace_scan_directory_index(db, directory_mtimes)
+            set_scan_cache_meta(db, "excluded_paths", self.excluded_paths)
+            set_scan_cache_meta(db, "excluded_patterns", self.excluded_patterns)
             db.close()
             self.progress_signal.emit(scanned, total, "", time.perf_counter() - started_at)
-            self.finished_signal.emit(True, "Library scanning complete!")
+            self.finished_signal.emit(
+                True,
+                f"Library scanning complete. Updated {updated}, unchanged {unchanged}, removed {removed}.",
+            )
         except Exception as e:
             if db is not None:
                 db.close()

--- a/src/ui/workers/library_scanner.py
+++ b/src/ui/workers/library_scanner.py
@@ -5,18 +5,14 @@ from PySide6.QtCore import QThread, Signal
 
 from library.scan_library import (
     get_audio_file_signature,
-    iter_audio_paths_with_directory_cache,
+    iter_audio_paths,
     new_fs_track_from_path,
 )
 from db.database import (
     add_tracks,
     delete_tracks_by_paths,
     get_library_file_index,
-    get_scan_cache_meta,
-    get_scan_directory_index,
     prune_library,
-    replace_scan_directory_index,
-    set_scan_cache_meta,
 )
 
 class LibraryScanner(QThread):
@@ -46,17 +42,8 @@ class LibraryScanner(QThread):
             db.row_factory = sqlite3.Row
 
             existing_index = get_library_file_index(db)
-            previous_excluded_paths = get_scan_cache_meta(db, "excluded_paths")
-            previous_excluded_patterns = get_scan_cache_meta(db, "excluded_patterns")
-            cache_compatible = (
-                previous_excluded_paths == self.excluded_paths
-                and previous_excluded_patterns == self.excluded_patterns
-            )
-            cached_directory_mtimes = get_scan_directory_index(db) if cache_compatible else {}
-            paths, directory_mtimes = iter_audio_paths_with_directory_cache(
+            paths = iter_audio_paths(
                 self.directories,
-                existing_paths=list(existing_index.keys()),
-                cached_directory_mtimes=cached_directory_mtimes,
                 excluded_paths=self.excluded_paths,
                 excluded_patterns=self.excluded_patterns,
             )
@@ -68,9 +55,7 @@ class LibraryScanner(QThread):
 
             current_path_set = set(paths)
             removed_paths = [path for path in existing_index.keys() if path not in current_path_set]
-            if removed_paths:
-                delete_tracks_by_paths(db, removed_paths)
-                removed = len(removed_paths)
+            removed = len(removed_paths)
 
             batch = []
             pending_replacements: list[str] = []
@@ -92,7 +77,7 @@ class LibraryScanner(QThread):
                 if p in existing_index:
                     pending_replacements.append(p)
 
-                t = new_fs_track_from_path(p)
+                t = new_fs_track_from_path(p, signature=signature)
 
                 if t is not None:
                     batch.append(t)
@@ -124,10 +109,10 @@ class LibraryScanner(QThread):
                     db.rollback()
                     raise
 
+            if removed_paths:
+                delete_tracks_by_paths(db, removed_paths)
+
             prune_library(db)
-            replace_scan_directory_index(db, directory_mtimes)
-            set_scan_cache_meta(db, "excluded_paths", self.excluded_paths)
-            set_scan_cache_meta(db, "excluded_patterns", self.excluded_patterns)
             db.close()
             self.progress_signal.emit(scanned, total, "", time.perf_counter() - started_at)
             self.finished_signal.emit(

--- a/src/ui/workers/library_scanner.py
+++ b/src/ui/workers/library_scanner.py
@@ -10,16 +10,29 @@ class LibraryScanner(QThread):
     progress_signal = Signal(int, int, str, float)     # scanned, total, current path, elapsed seconds
     finished_signal = Signal(bool, str)    # ok, message
 
-    def __init__(self, db_path: str, directories: list[str]):
+    def __init__(
+        self,
+        db_path: str,
+        directories: list[str],
+        *,
+        excluded_paths: str = "",
+        excluded_patterns: str = "",
+    ):
         super().__init__()
         self.db_path = db_path
         self.directories = directories
+        self.excluded_paths = excluded_paths
+        self.excluded_patterns = excluded_patterns
 
     def run(self):
         db = None
         started_at = time.perf_counter()
         try:
-            paths = iter_audio_paths(self.directories)
+            paths = iter_audio_paths(
+                self.directories,
+                excluded_paths=self.excluded_paths,
+                excluded_patterns=self.excluded_patterns,
+            )
             total = len(paths)
             scanned = 0
 

--- a/src/ui/workers/library_scanner.py
+++ b/src/ui/workers/library_scanner.py
@@ -73,6 +73,7 @@ class LibraryScanner(QThread):
                 removed = len(removed_paths)
 
             batch = []
+            pending_replacements: list[str] = []
             for p in paths:
                 if self.isInterruptionRequested():
                     if db is not None:
@@ -89,7 +90,7 @@ class LibraryScanner(QThread):
                     continue
 
                 if p in existing_index:
-                    delete_tracks_by_paths(db, [p])
+                    pending_replacements.append(p)
 
                 t = new_fs_track_from_path(p)
 
@@ -98,15 +99,30 @@ class LibraryScanner(QThread):
                     updated += 1
 
                 if len(batch) >= 100:
-                    add_tracks(db, batch)   # later replace with add_tracks_bulk
+                    db.execute("BEGIN")
+                    try:
+                        delete_tracks_by_paths(db, pending_replacements, commit=False)
+                        add_tracks(db, batch, commit=False)
+                        db.commit()
+                    except Exception:
+                        db.rollback()
+                        raise
                     batch.clear()
+                    pending_replacements.clear()
                     self.progress_signal.emit(scanned, total, p, time.perf_counter() - started_at)
 
                 if scanned % 200 == 0:
                     self.progress_signal.emit(scanned, total, p, time.perf_counter() - started_at)
 
-            if batch:
-                add_tracks(db, batch)
+            if batch or pending_replacements:
+                db.execute("BEGIN")
+                try:
+                    delete_tracks_by_paths(db, pending_replacements, commit=False)
+                    add_tracks(db, batch, commit=False)
+                    db.commit()
+                except Exception:
+                    db.rollback()
+                    raise
 
             prune_library(db)
             replace_scan_directory_index(db, directory_mtimes)


### PR DESCRIPTION
## Summary

This PR improves lyric syncing ergonomics and makes library refreshes much faster on larger collections.

## What changed

- add reaction delay support for lyric snapping during sync
- add custom playback speed input, +/- controls, and persistence across sessions
- add excluded paths and regex patterns for library scanning, with exclusion preview in settings
- make library scans incremental using file signatures instead of clearing and rebuilding everything
- add directory mtime cache to avoid re-walking unchanged subtrees
- harden scanning against unreadable/corrupt audio files so one bad file does not stop the scan

## Notes

- reaction delay is configurable in Settings and applies to Snap while syncing
- playback speed now supports presets, custom values, and restoring the last used speed at startup
- incremental scans also consider `.txt` and `.lrc` sidecars in the file signature

## Verification

- ran `py_compile` on modified Python files successfully