### PR TITLE
feat(lyrics): batch retry failed downloads with relaxed search

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,12 +45,15 @@ jobs:
           - os: windows-latest
             archive_name: pylrcget-windows.zip
             installer_name: pylrcget-windows-installer.exe
+            portable_name: pylrcget-windows-portable.exe
           - os: ubuntu-latest
             archive_name: pylrcget-linux.tar.gz
             installer_name: pylrcget-linux.deb
+            portable_name: pylrcget-linux-portable
           - os: macos-latest
             archive_name: pylrcget-macos.tar.gz
             installer_name: pylrcget-macos.pkg
+            portable_name: pylrcget-macos-portable
 
     steps:
       - uses: actions/checkout@v4
@@ -69,6 +72,18 @@ jobs:
 
       - name: Build executable
         run: pyinstaller --noconfirm pylrcget.spec
+
+      - name: Build portable executable
+        run: pyinstaller --noconfirm pylrcget-portable.spec
+
+      - name: Rename portable executable (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: Move-Item -LiteralPath dist/pylrcget-portable.exe -Destination ${{ matrix.portable_name }} -Force
+
+      - name: Rename portable executable (Unix)
+        if: runner.os != 'Windows'
+        run: mv dist/pylrcget-portable "${{ matrix.portable_name }}"
 
       - name: Package archive (Windows)
         if: runner.os == 'Windows'
@@ -159,6 +174,12 @@ jobs:
           name: ${{ matrix.installer_name }}
           path: ${{ matrix.installer_name }}
 
+      - name: Upload workflow artifact (portable)
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.portable_name }}
+          path: ${{ matrix.portable_name }}
+
       - name: Upload release asset (archive)
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
@@ -168,3 +189,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
         run: gh release upload "${{ needs.release.outputs.tag }}" "${{ matrix.installer_name }}" --clobber
+
+      - name: Upload release asset (portable)
+        env:
+          GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}
+        run: gh release upload "${{ needs.release.outputs.tag }}" "${{ matrix.portable_name }}" --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ desktop.ini
 # Packaging / installers
 *.spec
 !pylrcget.spec
+!pylrcget-portable.spec
 
 # PyInstaller
 *.manifest

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Uses **semantic-release** with Conventional Commits. On every push to `main`, CI
 - Use Conventional Commits: `feat: ...`, `fix: ...`, `chore: ...`
 - Breaking changes: use `!` or a `BREAKING CHANGE:` footer
 - Build artifacts for Windows, Linux, and macOS are attached to GitHub Releases
+- Portable single-file executables are published as `pylrcget-windows-portable.exe`, `pylrcget-linux-portable`, and `pylrcget-macos-portable`
 
 ### 🛡️ Windows note
 
@@ -183,6 +184,8 @@ The `About` dialog checks GitHub Releases for newer versions:
 | Windows | `pylrcget-windows-installer.exe` (Inno Setup) |
 | macOS | `.dmg`, `.pkg` |
 | Linux | `.AppImage`, `.deb`, `.rpm` |
+
+Portable single-file builds are also attached to releases for manual download. In-app automatic install continues to prefer platform installer assets when available.
 
 Local feed testing is supported via `PYLRCGET_UPDATE_LATEST_URL` and `PYLRCGET_UPDATE_DEBUG` environment overrides.
 

--- a/pylrcget-portable.spec
+++ b/pylrcget-portable.spec
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+
+SPEC_PATH = Path(globals().get("__file__", "pylrcget-portable.spec")).resolve()
+ROOT = SPEC_PATH.parent if SPEC_PATH.exists() else Path.cwd()
+
+
+a = Analysis(
+    ["main.py"],
+    pathex=[str(ROOT), str(ROOT / "src")],
+    binaries=[],
+    datas=[
+        (str(ROOT / "src" / "ui" / "qss"), "ui/qss"),
+        (str(ROOT / "src" / "ui" / "assets"), "ui/assets"),
+        (str(ROOT / "pyproject.toml"), "."),
+    ],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name="pylrcget-portable",
+    icon=str(ROOT / "src" / "ui" / "assets" / "app-icon.ico"),
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,5 +22,7 @@ exclude_commit_patterns = [
 [tool.semantic_release.commit_parser_options]
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf", "refactor", "ci", "chore"]
-parse_squash_commits = false
+# GitHub squash merges keep the PR commits in the squash commit body. Parse that
+# body so release notes include each conventional commit from the PR branch.
+parse_squash_commits = true
 ignore_merge_commits = true

--- a/src/ui/controllers/lyrics_download_controller.py
+++ b/src/ui/controllers/lyrics_download_controller.py
@@ -8,18 +8,24 @@ from typing import Callable
 
 from PySide6.QtCore import QObject, QTimer
 
+from core.utils import plain_text_from_lrc
 from db.models import Track
 from db.queries import (
     get_config,
     get_track_by_id,
     get_track_ids_for_download_mode,
     record_download_history_batch,
+    update_track_plain_lyrics,
+    update_track_synced_lyrics,
 )
 from core.tracklist_models import DownloadState
 from ui.services.feedback import notify_user
 from ui.services.download_modes import download_mode_label, no_missing_tracks_message
+from ui.services.lyrics_match_retry import LyricsMatchCandidate
+from ui.services.lyrics_download_service import sync_track_outputs_with_result
 from ui.widgets.download_progress_overlay import DownloadProgressOverlay
 from ui.workers.bulk_lyrics_download_worker import BulkDownloadStats, BulkLyricsDownloadWorker
+from ui.workers.lyrics_retry_search_worker import LyricsRetrySearchWorker
 
 logger = logging.getLogger(__name__)
 
@@ -64,6 +70,12 @@ class LyricsDownloadController(QObject):
         self._active_track_ids: set[int] = set()
         self._state_tokens: dict[int, int] = {}
         self._pending_history_entries: list[dict[str, object]] = []
+        self._failed_download_track_ids: list[int] = []
+        self._retry_search_worker: LyricsRetrySearchWorker | None = None
+
+        retry_failed_signal = getattr(self._overlay, "retryFailedRequested", None)
+        if retry_failed_signal is not None:
+            retry_failed_signal.connect(self._retry_failed_downloads_with_search)
 
     def start_downloads(self, track_ids: list[int], *, mode_override: str = "use_global") -> None:
         request = self._build_request(track_ids, mode_override=mode_override)
@@ -75,6 +87,7 @@ class LyricsDownloadController(QObject):
         self._active_request = request
         self._active_track_ids = set(request.track_ids)
         self._pending_history_entries = []
+        self._failed_download_track_ids = []
 
         self._overlay.start_batch(self._download_mode_label(request.mode), len(request.track_ids))
         self._show_status(f"Starting lyrics download... ({request.lrclib_instance})", None)
@@ -107,6 +120,8 @@ class LyricsDownloadController(QObject):
 
     def cancel(self) -> None:
         if self._download_worker is None or not self._download_worker.isRunning():
+            if self._retry_search_worker is not None and self._retry_search_worker.isRunning():
+                self._retry_search_worker.requestInterruption()
             return
         self._download_worker.requestInterruption()
 
@@ -162,6 +177,10 @@ class LyricsDownloadController(QObject):
         self._active_track_ids.discard(int(track_id))
         state = DownloadState.SUCCESS if ok else DownloadState.ERROR
         self._set_track_download_state(int(track_id), state)
+        if not ok:
+            failed_id = int(track_id)
+            if failed_id not in self._failed_download_track_ids:
+                self._failed_download_track_ids.append(failed_id)
         self._overlay.append_result(track_label, msg, ok)
         history_entry = self._build_download_history_entry(int(track_id), track_label, msg)
         if history_entry is not None:
@@ -203,6 +222,10 @@ class LyricsDownloadController(QObject):
             "cancelled": bool(stats.get("cancelled")) if isinstance(stats, dict) else False,
         }
         self._overlay.finish_batch(msg, cancelled=bool(stats_dict.get("cancelled")))
+        show_retry_failed = getattr(self._overlay, "show_retry_failed", None)
+        if callable(show_retry_failed):
+            retry_count = 0 if stats_dict.get("cancelled") else len(self._failed_download_track_ids)
+            show_retry_failed(retry_count)
         if stats_dict.get("cancelled"):
             notify_user(
                 self._app_state,
@@ -232,6 +255,124 @@ class LyricsDownloadController(QObject):
                 queue_auto_close(2200)
         self._download_worker = None
         self._active_request = None
+
+    def _retry_failed_downloads_with_search(self) -> None:
+        failed_ids = list(dict.fromkeys(self._failed_download_track_ids))
+        if not failed_ids:
+            return
+        if self._retry_search_worker is not None and self._retry_search_worker.isRunning():
+            return
+        config = get_config(self._app_state.db)
+        lrclib_instance = self._normalize_lrclib_base(config.lrclib_instance or "https://lrclib.net")
+
+        self._overlay.start_batch("Retry failed search", len(failed_ids))
+        self._show_status("Searching LRCLIB with relaxed queries...", None)
+        self._retry_search_worker = LyricsRetrySearchWorker(
+            self._app_state.db_path,
+            failed_ids,
+            lrclib_instance,
+            parent=self,
+        )
+        self._retry_search_worker.progress.connect(self._on_retry_search_progress)
+        self._retry_search_worker.finishedSearch.connect(self._on_retry_search_finished)
+        self._retry_search_worker.start()
+
+    def _on_retry_search_progress(self, current: int, total: int, track_label: str, status: str) -> None:
+        self._overlay.update_progress(current, total, track_label, status)
+        self._show_status(status, None)
+
+    def _on_retry_search_finished(self, candidates: list, error: str) -> None:
+        self._retry_search_worker = None
+        if error:
+            msg = f"Relaxed lyrics search failed: {error}"
+            self._overlay.finish_batch(msg)
+            notify_user(self._app_state, msg, "error", show_status=self._show_status, status_timeout_ms=4500)
+            return
+
+        if not candidates:
+            msg = "Relaxed lyrics search finished. No candidate matches found."
+            self._overlay.finish_batch(msg)
+            notify_user(self._app_state, msg, "warning", show_status=self._show_status, status_timeout_ms=4500)
+            return
+
+        self._overlay.finish_batch(f"Relaxed lyrics search found {len(candidates)} candidate match(es).")
+        self._review_retry_candidates([candidate for candidate in candidates if isinstance(candidate, LyricsMatchCandidate)])
+
+    def _review_retry_candidates(self, candidates: list[LyricsMatchCandidate]) -> None:
+        from ui.dialogs.batch_lyrics_match_dialog import BatchLyricsMatchDialog
+
+        dialog = BatchLyricsMatchDialog(candidates, parent=self.parent())
+        if not dialog.exec():
+            return
+        selected = dialog.selected_candidates()
+        if not selected:
+            notify_user(
+                self._app_state,
+                "No retry matches were selected.",
+                "info",
+                show_status=self._show_status,
+                status_timeout_ms=3000,
+            )
+            return
+
+        applied_count = 0
+        for candidate in selected:
+            if self._apply_retry_candidate(candidate):
+                applied_count += 1
+
+        if not applied_count:
+            return
+        self._flush_pending_download_history()
+        self._refresh_visible_library_view()
+        self._refresh_history()
+        notify_user(
+            self._app_state,
+            f"Applied lyrics to {applied_count} failed track{'s' if applied_count != 1 else ''}.",
+            "success",
+            show_status=self._show_status,
+            status_timeout_ms=3500,
+        )
+
+    def _apply_retry_candidate(self, candidate: LyricsMatchCandidate) -> bool:
+        try:
+            track = get_track_by_id(self._app_state.db, int(candidate.track_id))
+        except (sqlite3.Error, AttributeError, TypeError) as exc:
+            logger.warning("Failed to load track for lyrics retry candidate %s: %s", candidate.track_id, exc)
+            return False
+
+        updated = self._apply_selected_lyrics(candidate.track_id, candidate.plain_lyrics, candidate.synced_lyrics)
+        if updated is None:
+            return False
+
+        message = "Downloaded synced lyrics via relaxed search." if updated.lrc_lyrics else "Downloaded plain lyrics via relaxed search."
+        history_entry = self._build_download_history_entry(
+            int(candidate.track_id),
+            f"{track.artist_name or ''} - {track.title or ''}".strip(" -"),
+            message,
+        )
+        if history_entry is not None:
+            self._pending_history_entries.append(history_entry)
+
+        self._set_track_download_state(int(candidate.track_id), DownloadState.SUCCESS)
+        if self._current_player_track_id() == int(candidate.track_id):
+            self._set_track_lyrics_views(updated)
+        return True
+
+    def _apply_selected_lyrics(self, track_id: int, plain: str, synced: str) -> Track | None:
+        synced_text = (synced or "").strip()
+        plain_text = (plain or "").strip()
+        if synced_text:
+            if not plain_text:
+                plain_text = plain_text_from_lrc(synced_text)
+            track = update_track_synced_lyrics(self._app_state.db, int(track_id), synced_text, plain_text)
+        elif plain_text:
+            track = update_track_plain_lyrics(self._app_state.db, int(track_id), plain_text)
+        else:
+            return None
+
+        config = get_config(self._app_state.db)
+        sync_track_outputs_with_result(track, config)
+        return track
 
     def _reset_track_download_state_if_unchanged(
         self,

--- a/src/ui/controllers/lyrics_download_controller.py
+++ b/src/ui/controllers/lyrics_download_controller.py
@@ -119,11 +119,10 @@ class LyricsDownloadController(QObject):
         self.start_downloads(track_ids, mode_override=mode)
 
     def cancel(self) -> None:
-        if self._download_worker is None or not self._download_worker.isRunning():
-            if self._retry_search_worker is not None and self._retry_search_worker.isRunning():
-                self._retry_search_worker.requestInterruption()
-            return
-        self._download_worker.requestInterruption()
+        if self._download_worker is not None and self._download_worker.isRunning():
+            self._download_worker.requestInterruption()
+        if self._retry_search_worker is not None and self._retry_search_worker.isRunning():
+            self._retry_search_worker.requestInterruption()
 
     def _resolve_download_mode(self, mode_override: str = "use_global") -> str:
         if mode_override and mode_override != "use_global":

--- a/src/ui/controllers/lyrics_download_controller.py
+++ b/src/ui/controllers/lyrics_download_controller.py
@@ -19,6 +19,7 @@ from db.queries import (
     update_track_synced_lyrics,
 )
 from core.tracklist_models import DownloadState
+from ui.dialogs.batch_lyrics_match_dialog import BatchLyricsMatchDialog
 from ui.services.feedback import notify_user
 from ui.services.download_modes import download_mode_label, no_missing_tracks_message
 from ui.services.lyrics_match_retry import LyricsMatchCandidate
@@ -298,8 +299,6 @@ class LyricsDownloadController(QObject):
         self._review_retry_candidates([candidate for candidate in candidates if isinstance(candidate, LyricsMatchCandidate)])
 
     def _review_retry_candidates(self, candidates: list[LyricsMatchCandidate]) -> None:
-        from ui.dialogs.batch_lyrics_match_dialog import BatchLyricsMatchDialog
-
         dialog = BatchLyricsMatchDialog(candidates, parent=self.parent())
         if not dialog.exec():
             return

--- a/src/ui/dialogs/about_dialog.py
+++ b/src/ui/dialogs/about_dialog.py
@@ -5,7 +5,6 @@ from pathlib import Path
 from PySide6.QtCore import QTimer, QUrl
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
-    QApplication,
     QDialog,
     QHBoxLayout,
     QLabel,
@@ -197,6 +196,7 @@ class AboutDialog(QDialog):
                 self,
                 "Ready to install",
                 "The update installer will now launch.\n"
+                "The application will close automatically.\n"
                 "Follow the on-screen prompts to proceed with the installation.",
             )
             try:
@@ -205,7 +205,10 @@ class AboutDialog(QDialog):
                 self.status_label.setText(f"Could not stage the update: {exc}")
                 return
 
-            QApplication.quit()
+            # Do NOT quit here — let the Inno Setup installer close the app
+            # via /CLOSEAPPLICATIONS so that Restart Manager can reopen it
+            # after the update finishes.
+            self.status_label.setText("Waiting for installer…")
             return
 
         self.status_label.setText(f"Update downloaded to {download_path}")

--- a/src/ui/dialogs/batch_lyrics_match_dialog.py
+++ b/src/ui/dialogs/batch_lyrics_match_dialog.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QDialogButtonBox,
+    QHeaderView,
+    QLabel,
+    QTableWidget,
+    QTableWidgetItem,
+    QVBoxLayout,
+)
+
+from ui.services.lyrics_match_retry import LyricsMatchCandidate
+
+
+CANDIDATE_ROLE = Qt.ItemDataRole.UserRole
+
+
+class BatchLyricsMatchDialog(QDialog):
+    def __init__(self, candidates: list[LyricsMatchCandidate], parent=None) -> None:
+        super().__init__(parent)
+        self.setWindowTitle("Review LRCLIB Matches")
+        self.resize(980, 520)
+        self._candidates = list(candidates)
+
+        layout = QVBoxLayout(self)
+        self.summary_label = QLabel(f"Review {len(self._candidates)} best match(es) found for failed downloads.")
+        self.summary_label.setWordWrap(True)
+        layout.addWidget(self.summary_label)
+
+        self.table = QTableWidget(0, 7)
+        self.table.setHorizontalHeaderLabels(["Apply", "Track", "Best match", "Album", "Score", "Type", "Found by"])
+        self.table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self.table.setSelectionMode(QTableWidget.SelectionMode.SingleSelection)
+        self.table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self.table.verticalHeader().setVisible(False)
+        header = self.table.horizontalHeader()
+        header.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(2, QHeaderView.ResizeMode.Stretch)
+        header.setSectionResizeMode(3, QHeaderView.ResizeMode.Interactive)
+        header.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(5, QHeaderView.ResizeMode.ResizeToContents)
+        header.setSectionResizeMode(6, QHeaderView.ResizeMode.ResizeToContents)
+        layout.addWidget(self.table, 1)
+
+        buttons = QDialogButtonBox(QDialogButtonBox.StandardButton.Ok | QDialogButtonBox.StandardButton.Cancel)
+        buttons.button(QDialogButtonBox.StandardButton.Ok).setText("Apply Checked")
+        buttons.accepted.connect(self.accept)
+        buttons.rejected.connect(self.reject)
+        layout.addWidget(buttons)
+
+        self._populate()
+
+    def selected_candidates(self) -> list[LyricsMatchCandidate]:
+        selected: list[LyricsMatchCandidate] = []
+        for row in range(self.table.rowCount()):
+            item = self.table.item(row, 0)
+            if item is None or item.checkState() != Qt.CheckState.Checked:
+                continue
+            candidate = item.data(CANDIDATE_ROLE)
+            if isinstance(candidate, LyricsMatchCandidate):
+                selected.append(candidate)
+        return selected
+
+    def _populate(self) -> None:
+        self.table.setRowCount(len(self._candidates))
+        for row, candidate in enumerate(self._candidates):
+            apply_item = QTableWidgetItem("")
+            apply_item.setFlags(
+                Qt.ItemFlag.ItemIsUserCheckable
+                | Qt.ItemFlag.ItemIsEnabled
+                | Qt.ItemFlag.ItemIsSelectable
+            )
+            apply_item.setCheckState(Qt.CheckState.Checked if candidate.score >= 72 else Qt.CheckState.Unchecked)
+            apply_item.setData(CANDIDATE_ROLE, candidate)
+            self.table.setItem(row, 0, apply_item)
+
+            self.table.setItem(row, 1, QTableWidgetItem(candidate.track_label))
+            self.table.setItem(row, 2, QTableWidgetItem(f"{candidate.artist_name} - {candidate.track_name}".strip(" -")))
+            self.table.setItem(row, 3, QTableWidgetItem(candidate.album_name))
+            self.table.setItem(row, 4, QTableWidgetItem(f"{candidate.score}%"))
+            self.table.setItem(row, 5, QTableWidgetItem(candidate.kind))
+            self.table.setItem(row, 6, QTableWidgetItem(candidate.query_label))

--- a/src/ui/dialogs/search_lyrics_dialog.py
+++ b/src/ui/dialogs/search_lyrics_dialog.py
@@ -105,6 +105,16 @@ class SearchLyricsDialog(QDialog):
         fields_row.addWidget(self.search_btn)
         layout.addLayout(fields_row)
 
+        refine_row = QHBoxLayout()
+        refine_row.addStretch(1)
+        self.artist_title_btn = QPushButton("Artist + title only")
+        self.clear_album_btn = QPushButton("Clear album")
+        self.free_text_btn = QPushButton("Use free-text query")
+        refine_row.addWidget(self.artist_title_btn)
+        refine_row.addWidget(self.clear_album_btn)
+        refine_row.addWidget(self.free_text_btn)
+        layout.addLayout(refine_row)
+
         self.status_label = QLabel("")
         layout.addWidget(self.status_label)
 
@@ -132,6 +142,9 @@ class SearchLyricsDialog(QDialog):
         layout.addLayout(btn_row)
 
         self.search_btn.clicked.connect(self._do_search)
+        self.artist_title_btn.clicked.connect(self._search_artist_title_only)
+        self.clear_album_btn.clicked.connect(self._clear_album_and_search)
+        self.free_text_btn.clicked.connect(self._search_free_text)
         self.query_edit.returnPressed.connect(self._do_search)
         self.artist_edit.returnPressed.connect(self._do_search)
         self.title_edit.returnPressed.connect(self._do_search)
@@ -143,6 +156,25 @@ class SearchLyricsDialog(QDialog):
 
         if initial_query.strip() or initial_artist.strip() or initial_title.strip():
             self._do_search()
+
+    def _search_artist_title_only(self):
+        self.query_edit.clear()
+        self.album_edit.clear()
+        self._do_search()
+
+    def _clear_album_and_search(self):
+        self.album_edit.clear()
+        self._do_search()
+
+    def _search_free_text(self):
+        artist = self.artist_edit.text().strip()
+        title = self.title_edit.text().strip()
+        query = " ".join(part for part in (artist, title) if part)
+        self.query_edit.setText(query)
+        self.artist_edit.clear()
+        self.title_edit.clear()
+        self.album_edit.clear()
+        self._do_search()
 
     def _do_search(self):
         query = self.query_edit.text().strip()

--- a/src/ui/services/lyrics_match_retry.py
+++ b/src/ui/services/lyrics_match_retry.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from difflib import SequenceMatcher
+import re
+
+
+_WORD_RE = re.compile(r"[a-z0-9]+")
+
+
+@dataclass(frozen=True)
+class RetrySearchQuery:
+    label: str
+    query: str = ""
+    artist: str = ""
+    title: str = ""
+    album: str = ""
+
+
+@dataclass(frozen=True)
+class LyricsMatchCandidate:
+    track_id: int
+    track_label: str
+    query_label: str
+    score: int
+    artist_name: str
+    track_name: str
+    album_name: str
+    duration: int
+    kind: str
+    plain_lyrics: str
+    synced_lyrics: str
+
+
+def build_retry_search_queries(*, artist: str, title: str, album: str) -> list[RetrySearchQuery]:
+    artist = (artist or "").strip()
+    title = (title or "").strip()
+    album = (album or "").strip()
+    queries: list[RetrySearchQuery] = []
+
+    if title and artist and album:
+        queries.append(RetrySearchQuery("artist + title + album", artist=artist, title=title, album=album))
+    if title and artist:
+        queries.append(RetrySearchQuery("artist + title", artist=artist, title=title))
+        queries.append(RetrySearchQuery("free text: artist title", query=f"{artist} {title}"))
+    if title:
+        queries.append(RetrySearchQuery("title only", title=title))
+        queries.append(RetrySearchQuery("free text: title", query=title))
+
+    unique: list[RetrySearchQuery] = []
+    seen: set[tuple[str, str, str, str]] = set()
+    for item in queries:
+        key = (item.query.casefold(), item.artist.casefold(), item.title.casefold(), item.album.casefold())
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(item)
+    return unique
+
+
+def choose_best_candidate(
+    *,
+    track_id: int,
+    track_label: str,
+    artist: str,
+    title: str,
+    album: str,
+    query_label: str,
+    results: list,
+) -> LyricsMatchCandidate | None:
+    best: LyricsMatchCandidate | None = None
+    for result in results:
+        score = _score_result(
+            artist=artist,
+            title=title,
+            album=album,
+            result_artist=str(getattr(result, "artist_name", "") or ""),
+            result_title=str(getattr(result, "track_name", "") or ""),
+            result_album=str(getattr(result, "album_name", "") or ""),
+        )
+        kind = _result_kind(result)
+        if kind not in {"Synced", "Plain"}:
+            continue
+        if kind == "Synced":
+            score += 3
+        candidate = LyricsMatchCandidate(
+            track_id=int(track_id),
+            track_label=track_label,
+            query_label=query_label,
+            score=min(100, score),
+            artist_name=str(getattr(result, "artist_name", "") or ""),
+            track_name=str(getattr(result, "track_name", "") or ""),
+            album_name=str(getattr(result, "album_name", "") or ""),
+            duration=int(getattr(result, "duration", 0) or 0),
+            kind=kind,
+            plain_lyrics=str(getattr(result, "plain_lyrics", "") or ""),
+            synced_lyrics=str(getattr(result, "synced_lyrics", "") or ""),
+        )
+        if best is None or candidate.score > best.score:
+            best = candidate
+    return best
+
+
+def _score_result(
+    *,
+    artist: str,
+    title: str,
+    album: str,
+    result_artist: str,
+    result_title: str,
+    result_album: str,
+) -> int:
+    title_score = _text_similarity(title, result_title)
+    artist_score = _text_similarity(artist, result_artist)
+    album_score = _text_similarity(album, result_album) if album.strip() else 0.0
+    score = (title_score * 0.58) + (artist_score * 0.34) + (album_score * 0.08)
+    return int(round(score * 100))
+
+
+def _text_similarity(left: str, right: str) -> float:
+    left_norm = _normalize_text(left)
+    right_norm = _normalize_text(right)
+    if not left_norm or not right_norm:
+        return 0.0
+    if left_norm == right_norm:
+        return 1.0
+    left_tokens = set(left_norm.split())
+    right_tokens = set(right_norm.split())
+    token_score = len(left_tokens & right_tokens) / max(1, len(left_tokens | right_tokens))
+    sequence_score = SequenceMatcher(None, left_norm, right_norm).ratio()
+    return max(token_score, sequence_score)
+
+
+def _normalize_text(value: str) -> str:
+    return " ".join(_WORD_RE.findall((value or "").casefold()))
+
+
+def _result_kind(result) -> str:
+    if getattr(result, "synced_lyrics", None):
+        return "Synced"
+    if getattr(result, "plain_lyrics", None):
+        return "Plain"
+    if getattr(result, "instrumental", False):
+        return "Instrumental"
+    return "None"

--- a/src/ui/services/lyrics_match_retry.py
+++ b/src/ui/services/lyrics_match_retry.py
@@ -6,6 +6,10 @@ import re
 
 
 _WORD_RE = re.compile(r"[a-z0-9]+")
+TITLE_SCORE_WEIGHT = 0.58
+ARTIST_SCORE_WEIGHT = 0.34
+ALBUM_SCORE_WEIGHT = 0.08
+SYNCED_LYRICS_SCORE_BONUS = 3
 
 
 @dataclass(frozen=True)
@@ -82,7 +86,7 @@ def choose_best_candidate(
         if kind not in {"Synced", "Plain"}:
             continue
         if kind == "Synced":
-            score += 3
+            score += SYNCED_LYRICS_SCORE_BONUS
         candidate = LyricsMatchCandidate(
             track_id=int(track_id),
             track_label=track_label,
@@ -113,7 +117,11 @@ def _score_result(
     title_score = _text_similarity(title, result_title)
     artist_score = _text_similarity(artist, result_artist)
     album_score = _text_similarity(album, result_album) if album.strip() else 0.0
-    score = (title_score * 0.58) + (artist_score * 0.34) + (album_score * 0.08)
+    score = (
+        (title_score * TITLE_SCORE_WEIGHT)
+        + (artist_score * ARTIST_SCORE_WEIGHT)
+        + (album_score * ALBUM_SCORE_WEIGHT)
+    )
     return int(round(score * 100))
 
 

--- a/src/ui/widgets/download_progress_overlay.py
+++ b/src/ui/widgets/download_progress_overlay.py
@@ -21,6 +21,7 @@ from ui.theme_tokens import STYLE_TOKENS
 
 class DownloadProgressOverlay(QWidget):
     cancelRequested = Signal()
+    retryFailedRequested = Signal()
     dismissed = Signal()
     minimized = Signal()           # overlay hidden while operation still running
     activeChanged = Signal(bool)   # True = batch started, False = batch finished/cancelled
@@ -105,6 +106,11 @@ class DownloadProgressOverlay(QWidget):
         self.stop_btn = QPushButton("STOP")
         self.stop_btn.setObjectName("DownloadOverlayStop")
         self.stop_btn.clicked.connect(self._handle_cancel)
+        self.retry_failed_btn = QPushButton("RETRY FAILED")
+        self.retry_failed_btn.setObjectName("DownloadOverlayRetry")
+        self.retry_failed_btn.hide()
+        self.retry_failed_btn.clicked.connect(self.retryFailedRequested.emit)
+        actions_row.addWidget(self.retry_failed_btn)
         actions_row.addWidget(self.stop_btn)
         actions_row.addStretch(1)
         card_layout.addLayout(actions_row)
@@ -132,6 +138,8 @@ class DownloadProgressOverlay(QWidget):
         self.output.clear()
         self.stop_btn.setText("STOP")
         self.stop_btn.setEnabled(True)
+        self.retry_failed_btn.hide()
+        self.retry_failed_btn.setEnabled(False)
         self.close_btn.setEnabled(True)
         self._refresh_summary()
         self.sync_to_parent()
@@ -177,6 +185,17 @@ class DownloadProgressOverlay(QWidget):
         else:
             self.title_label.setText(f"{self._verb} Complete")
         self.activeChanged.emit(False)
+
+    def show_retry_failed(self, count: int) -> None:
+        count = max(0, int(count))
+        if count <= 0:
+            self.retry_failed_btn.hide()
+            self.retry_failed_btn.setEnabled(False)
+            return
+        label = "RETRY FAILED" if count == 1 else f"RETRY {count} FAILED"
+        self.retry_failed_btn.setText(label)
+        self.retry_failed_btn.setEnabled(True)
+        self.retry_failed_btn.show()
 
     def queue_auto_close(self, delay_ms: int) -> None:
         if self._active:

--- a/src/ui/workers/lyrics_retry_search_worker.py
+++ b/src/ui/workers/lyrics_retry_search_worker.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import sqlite3
+import time
+
+from PySide6.QtCore import QObject, QThread, Signal
+
+from core.lrclib_client import LrcLibAPI
+from db.queries import get_track_by_id
+from ui.services.lyrics_match_retry import (
+    LyricsMatchCandidate,
+    build_retry_search_queries,
+    choose_best_candidate,
+)
+
+
+class LyricsRetrySearchWorker(QThread):
+    progress = Signal(int, int, str, str)  # current, total, track label, status
+    finishedSearch = Signal(list, str)  # list[LyricsMatchCandidate], error
+
+    def __init__(
+        self,
+        db_path: str,
+        track_ids: list[int],
+        lrclib_instance: str,
+        *,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.db_path = db_path
+        self.track_ids = [int(track_id) for track_id in track_ids]
+        self.lrclib_instance = lrclib_instance
+
+    def run(self) -> None:
+        total = len(self.track_ids)
+        candidates: list[LyricsMatchCandidate] = []
+        db = None
+        try:
+            db = sqlite3.connect(self.db_path, timeout=15.0)
+            db.row_factory = sqlite3.Row
+            api = LrcLibAPI(self.lrclib_instance)
+
+            for idx, track_id in enumerate(self.track_ids, start=1):
+                if self.isInterruptionRequested():
+                    break
+
+                track = get_track_by_id(db, track_id)
+                title = (track.title or "").strip()
+                artist = (track.artist_name or "").strip()
+                album = (track.album_name or "").strip()
+                label = f"{artist} - {title}".strip(" -") or f"Track {track_id}"
+                best: LyricsMatchCandidate | None = None
+
+                queries = build_retry_search_queries(artist=artist, title=title, album=album)
+                for query_idx, query in enumerate(queries, start=1):
+                    if self.isInterruptionRequested():
+                        break
+                    self.progress.emit(idx - 1, total, label, f"Trying {query.label}...")
+                    results = api.search_lyrics(
+                        query=query.query or None,
+                        track_name=query.title or None,
+                        artist_name=query.artist or None,
+                        album_name=query.album or None,
+                    )
+                    candidate = choose_best_candidate(
+                        track_id=track_id,
+                        track_label=label,
+                        artist=artist,
+                        title=title,
+                        album=album,
+                        query_label=query.label,
+                        results=results,
+                    )
+                    if candidate is not None and (best is None or candidate.score > best.score):
+                        best = candidate
+                    if query_idx < len(queries):
+                        time.sleep(0.15)
+
+                if best is not None:
+                    candidates.append(best)
+                    self.progress.emit(idx, total, label, f"Best match: {best.score}%")
+                else:
+                    self.progress.emit(idx, total, label, "No relaxed match found.")
+                if idx < total:
+                    time.sleep(0.25)
+
+            self.finishedSearch.emit(candidates, "")
+        except Exception as exc:
+            self.finishedSearch.emit(candidates, str(exc))
+        finally:
+            if db is not None:
+                db.close()

--- a/src/ui/workers/lyrics_retry_search_worker.py
+++ b/src/ui/workers/lyrics_retry_search_worker.py
@@ -44,7 +44,14 @@ class LyricsRetrySearchWorker(QThread):
                 if self.isInterruptionRequested():
                     break
 
-                track = get_track_by_id(db, track_id)
+                try:
+                    track = get_track_by_id(db, track_id)
+                except (sqlite3.Error, KeyError, TypeError):
+                    self.progress.emit(idx, total, f"Track {track_id}", "Track no longer exists; skipped.")
+                    continue
+                if track is None:
+                    self.progress.emit(idx, total, f"Track {track_id}", "Track no longer exists; skipped.")
+                    continue
                 title = (track.title or "").strip()
                 artist = (track.artist_name or "").strip()
                 album = (track.album_name or "").strip()
@@ -56,23 +63,27 @@ class LyricsRetrySearchWorker(QThread):
                     if self.isInterruptionRequested():
                         break
                     self.progress.emit(idx - 1, total, label, f"Trying {query.label}...")
-                    results = api.search_lyrics(
-                        query=query.query or None,
-                        track_name=query.title or None,
-                        artist_name=query.artist or None,
-                        album_name=query.album or None,
-                    )
-                    candidate = choose_best_candidate(
-                        track_id=track_id,
-                        track_label=label,
-                        artist=artist,
-                        title=title,
-                        album=album,
-                        query_label=query.label,
-                        results=results,
-                    )
-                    if candidate is not None and (best is None or candidate.score > best.score):
-                        best = candidate
+                    try:
+                        results = api.search_lyrics(
+                            query=query.query or None,
+                            track_name=query.title or None,
+                            artist_name=query.artist or None,
+                            album_name=query.album or None,
+                        )
+                        candidate = choose_best_candidate(
+                            track_id=track_id,
+                            track_label=label,
+                            artist=artist,
+                            title=title,
+                            album=album,
+                            query_label=query.label,
+                            results=results,
+                        )
+                        if candidate is not None and (best is None or candidate.score > best.score):
+                            best = candidate
+                    except Exception as exc:
+                        self.progress.emit(idx - 1, total, label, f"{query.label} failed: {type(exc).__name__}")
+                        continue
                     if query_idx < len(queries):
                         time.sleep(0.15)
 

--- a/templates/.release_notes.md.j2
+++ b/templates/.release_notes.md.j2
@@ -23,6 +23,9 @@
 ### {{ heading }}
 {%- for commit in bucket.items %}
 * {%- if commit.scope %} **{{ commit.scope }}:**{% endif %} {{ commit.descriptions[0] | capitalize }} ([{{ commit.hexsha[:7] }}]({{ commit.hexsha | commit_hash_url }}))
+{%- for description in commit.descriptions[1:] %}
+  {{ description }}
+{%- endfor %}
 {%- endfor %}
 {%- set any_changes.value = true -%}
 {%- endif %}
@@ -41,6 +44,9 @@
 ### 🔧 Other Changes
 {%- for commit in other.items %}
 * {%- if commit.scope %} **{{ commit.scope }}:**{% endif %} {{ commit.descriptions[0] | capitalize }} ([{{ commit.hexsha[:7] }}]({{ commit.hexsha | commit_hash_url }}))
+{%- for description in commit.descriptions[1:] %}
+  {{ description }}
+{%- endfor %}
 {%- endfor %}
 {%- set any_changes.value = true -%}
 {%- endif %}

--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -26,6 +26,9 @@
 ### {{ heading }}
 {%- for commit in bucket.items %}
 * {%- if commit.scope %} **{{ commit.scope }}:**{% endif %} {{ commit.descriptions[0] | capitalize }} ([{{ commit.hexsha[:7] }}]({{ commit.hexsha | commit_hash_url }}))
+{%- for description in commit.descriptions[1:] %}
+  {{ description }}
+{%- endfor %}
 {%- endfor %}
 {%- set any_changes.value = true -%}
 {%- endif %}
@@ -44,6 +47,9 @@
 ### 🔧 Other Changes
 {%- for commit in other.items %}
 * {%- if commit.scope %} **{{ commit.scope }}:**{% endif %} {{ commit.descriptions[0] | capitalize }} ([{{ commit.hexsha[:7] }}]({{ commit.hexsha | commit_hash_url }}))
+{%- for description in commit.descriptions[1:] %}
+  {{ description }}
+{%- endfor %}
 {%- endfor %}
 {%- set any_changes.value = true -%}
 {%- endif %}

--- a/tests/test_download_controller.py
+++ b/tests/test_download_controller.py
@@ -22,6 +22,7 @@ class _FakeOverlay:
         self.progress: list[tuple[int, int, str, str]] = []
         self.results: list[tuple[str, str, bool]] = []
         self.finished: list[tuple[str, bool]] = []
+        self.retry_failed_counts: list[int] = []
 
     def start_batch(self, mode_label: str, total: int) -> None:
         self.started.append((mode_label, total))
@@ -34,6 +35,9 @@ class _FakeOverlay:
 
     def finish_batch(self, message: str, *, cancelled: bool = False) -> None:
         self.finished.append((message, cancelled))
+
+    def show_retry_failed(self, count: int) -> None:
+        self.retry_failed_counts.append(int(count))
 
 
 class _FakeWorker(QObject):
@@ -217,6 +221,35 @@ class LyricsDownloadControllerTests(unittest.TestCase):
                 self.assertIn("view", refreshed)
                 self.assertIn("history", refreshed)
                 self.assertEqual(statuses[-1], ("Finished lyrics download. Success: 1, Failed: 0.", 4000))
+            finally:
+                db.close()
+
+    def test_failed_batch_exposes_manual_retry_action(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            db = initialize_database(tmp)
+            try:
+                app_state = SimpleNamespace(db=db, db_path=str(Path(tmp) / "pylrcget.db.sqlite3"))
+                overlay = _FakeOverlay()
+                controller, _, notifications, download_states, _ = self._make_controller(app_state, overlay)
+
+                with (
+                    patch("ui.controllers.lyrics_download_controller.BulkLyricsDownloadWorker", _FakeWorker),
+                    patch("ui.controllers.lyrics_download_controller.QTimer.singleShot"),
+                ):
+                    controller.start_downloads([41, 42], mode_override="prefer_synced")
+                    worker = _FakeWorker.instances[0]
+
+                    worker.itemFinished.emit(41, False, "Artist - Missing", "No lyrics found on LRCLIB for this track.")
+                    worker.itemFinished.emit(42, True, "Artist - Found", "Downloaded synced lyrics.")
+                    worker.finishedBatch.emit(
+                        True,
+                        "Finished lyrics download. Success: 1, Failed: 1.",
+                        {"ok": 1, "failed": 1, "cancelled": False},
+                    )
+
+                self.assertEqual(overlay.retry_failed_counts[-1], 1)
+                self.assertEqual(download_states[41], "error")
+                self.assertIn(("Finished lyrics download. Success: 1, Failed: 1.", "warning"), notifications)
             finally:
                 db.close()
 

--- a/tests/test_lyrics_match_retry.py
+++ b/tests/test_lyrics_match_retry.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+
+from tests import test_support as _test_support  # noqa: F401
+from ui.services.lyrics_match_retry import build_retry_search_queries, choose_best_candidate
+
+
+class LyricsMatchRetryTests(unittest.TestCase):
+    def test_build_retry_search_queries_relaxes_metadata_in_order(self):
+        queries = build_retry_search_queries(
+            artist="Air Supply",
+            title="All Out Of Love",
+            album="Greatest Hits",
+        )
+
+        self.assertEqual(
+            [query.label for query in queries],
+            [
+                "artist + title + album",
+                "artist + title",
+                "free text: artist title",
+                "title only",
+                "free text: title",
+            ],
+        )
+        self.assertEqual(queries[0].album, "Greatest Hits")
+        self.assertEqual(queries[1].album, "")
+
+    def test_choose_best_candidate_accepts_title_artist_match_when_album_differs(self):
+        results = [
+            SimpleNamespace(
+                artist_name="Someone Else",
+                track_name="All Out Of Love",
+                album_name="Lost in Love",
+                duration=240,
+                plain_lyrics="wrong",
+                synced_lyrics=None,
+                instrumental=False,
+            ),
+            SimpleNamespace(
+                artist_name="Air Supply",
+                track_name="All Out of Love",
+                album_name="Lost in Love",
+                duration=240,
+                plain_lyrics="plain",
+                synced_lyrics="[00:01.00]plain",
+                instrumental=False,
+            ),
+        ]
+
+        candidate = choose_best_candidate(
+            track_id=7,
+            track_label="Air Supply - All Out Of Love",
+            artist="Air Supply",
+            title="All Out Of Love",
+            album="Greatest Hits",
+            query_label="artist + title",
+            results=results,
+        )
+
+        self.assertIsNotNone(candidate)
+        assert candidate is not None
+        self.assertEqual(candidate.artist_name, "Air Supply")
+        self.assertEqual(candidate.album_name, "Lost in Love")
+        self.assertEqual(candidate.kind, "Synced")
+        self.assertGreaterEqual(candidate.score, 90)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lyrics_retry_search_worker.py
+++ b/tests/test_lyrics_retry_search_worker.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from tests import test_support as _test_support  # noqa: F401
+from tests.test_support import qt_app
+from ui.workers.lyrics_retry_search_worker import LyricsRetrySearchWorker
+
+
+class LyricsRetrySearchWorkerTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls._app = qt_app()
+
+    def test_continues_after_one_relaxed_query_fails(self):
+        track = SimpleNamespace(
+            id=12,
+            title="All Out Of Love",
+            artist_name="Air Supply",
+            album_name="Greatest Hits",
+        )
+        result = SimpleNamespace(
+            artist_name="Air Supply",
+            track_name="All Out of Love",
+            album_name="Lost in Love",
+            duration=240,
+            plain_lyrics="plain",
+            synced_lyrics="[00:01.00]plain",
+            instrumental=False,
+        )
+        fake_api = SimpleNamespace(
+            search_lyrics=MagicMock(side_effect=[RuntimeError("network"), [result], [], [], []])
+        )
+        worker = LyricsRetrySearchWorker("library.sqlite", [12], "https://lrclib.net/api")
+        emitted: list[tuple[list, str]] = []
+        worker.finishedSearch.connect(lambda candidates, error: emitted.append((candidates, error)))
+
+        with patch("ui.workers.lyrics_retry_search_worker.sqlite3.connect") as connect_mock, patch(
+            "ui.workers.lyrics_retry_search_worker.get_track_by_id",
+            return_value=track,
+        ), patch("ui.workers.lyrics_retry_search_worker.LrcLibAPI", return_value=fake_api), patch(
+            "ui.workers.lyrics_retry_search_worker.time.sleep"
+        ):
+            connect_mock.return_value.close.return_value = None
+            worker.run()
+
+        self.assertEqual(len(emitted), 1)
+        candidates, error = emitted[0]
+        self.assertEqual(error, "")
+        self.assertEqual(len(candidates), 1)
+        self.assertEqual(candidates[0].track_id, 12)
+        self.assertGreater(fake_api.search_lyrics.call_count, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- parse squash commit bodies so semantic-release includes PR commit changelog entries
- add batch relaxed-search retry flow for failed lyrics downloads
- show a review dialog with best LRCLIB matches before applying lyrics

## Tests
- .\\venv\\Scripts\\python.exe -m unittest tests.test_lyrics_match_retry tests.test_download_controller tests.test_download_worker -v